### PR TITLE
Workaround for problems with :reject_if => :all_blank

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -26,7 +26,7 @@ module Cocoon
 
         is_dynamic = f.object.new_record?
         html_options[:class] = [html_options[:class], "remove_fields #{is_dynamic ? 'dynamic' : 'existing'}"].compact.join(' ')
-        f.hidden_field(:_destroy) + link_to(name, '#', html_options)
+        hidden_field_tag("#{f.object_name}[_destroy]") + link_to(name, '#', html_options)
       end
     end
 


### PR DESCRIPTION
Let me start off by saying that I love cocoon. It saved me a lot of time. But it also caused me quite some headache, when I always found empty associations to be saved, even though I used accepts_nested_attributes_for with :reject_if => :all_blank in my model.

As it turns out, cocoon injects a hidden form field for the _delete value using ActionView's hidden_field helper. For a new record, this helper will set a value of "false". And while false.blank? is true, "false".blank? is not.

This effectively disabled the :all_blank check. I could have used custom Procs for :reject_if, as you do in your sample app, but that did not feel right.

My patch is maybe not the best solution, but it is the simplest I could come up with. And it works like a charm, as far as I can tell.

Anyways, I hope you fix the problem, with or without my trivial patch.

And keep up the good work!
