### PR TITLE
Fixed issues with extra blank records created when submitting form

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -61,12 +61,9 @@ module Cocoon
         html_options[:'data-association'] = association.to_s.singularize
 
         new_object = f.object.class.reflect_on_association(association).klass.new
-        model_name = new_object.class.name.underscore
-        hidden_div = content_tag('div', :id => "#{model_name}_fields_template", :style => "display:none;") do
-          render_association(association, f, new_object)
-        end
+        html_options[:'data-template'] = CGI.escapeHTML(render_association(association, f, new_object))
 
-        hidden_div.html_safe + link_to(name, '#', html_options )
+        link_to(name, '#', html_options )
       end
     end
 

--- a/lib/generators/cocoon/install/templates/cocoon.js
+++ b/lib/generators/cocoon/install/templates/cocoon.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
   $('.add_fields').live('click', function() {
     var assoc   = $(this).attr('data-association');
-    var content = $(this).siblings('#' + assoc + '_fields_template').html();
+    var content = $(this).attr('data-template');
     var insertionPosition = $(this).attr('data-association-insertion-position');
     var insertionNode = $(this).attr('data-association-insertion-node');
     var regexp_braced = new RegExp('\\[new_' + assoc + '\\]', 'g');

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -15,18 +15,18 @@ describe Cocoon do
       @tester = TestClass.new
       @post = Post.new
       @form_obj = stub(:object => @post)
-      @tester.stub(:render_association).and_return('form')
+      @tester.stub(:render_association).and_return('form<tag>')
     end
 
     context "without a block" do
       it "should accept a name" do
         result = @tester.link_to_add_association('add something', @form_obj, :comments)
-        result.to_s.should == '<div id="comment_fields_template" style="display:none;">form</div><a href="#" class="add_fields" data-association="comment">add something</a>'
+        result.to_s.should == '<a href="#" class="add_fields" data-association="comment" data-template="form&amp;lt;tag&amp;gt;">add something</a>'
       end
 
       it "should accept html options and pass them to link_to" do
         result = @tester.link_to_add_association('add something', @form_obj, :comments, {:class => 'something silly'})
-        result.to_s.should == "<div id=\"comment_fields_template\" style=\"display:none;\">form</div><a href=\"#\" class=\"something silly add_fields\" data-association=\"comment\">add something</a>"
+        result.to_s.should == '<a href="#" class="something silly add_fields" data-association="comment" data-template="form&amp;lt;tag&amp;gt;">add something</a>'
       end
     end
 
@@ -35,14 +35,14 @@ describe Cocoon do
         result = @tester.link_to_add_association(@form_obj, :comments) do
           "some long name"
         end
-        result.to_s.should == "<div id=\"comment_fields_template\" style=\"display:none;\">form</div><a href=\"#\" class=\"add_fields\" data-association=\"comment\">some long name</a>"
+        result.to_s.should == '<a href="#" class="add_fields" data-association="comment" data-template="form&amp;lt;tag&amp;gt;">some long name</a>'
       end
 
       it "should accept html options and pass them to link_to" do
         result = @tester.link_to_add_association(@form_obj, :comments, {:class => 'floppy disk'}) do
           "some long name"
         end
-        result.to_s.should == "<div id=\"comment_fields_template\" style=\"display:none;\">form</div><a href=\"#\" class=\"floppy disk add_fields\" data-association=\"comment\">some long name</a>"
+        result.to_s.should == '<a href="#" class="floppy disk add_fields" data-association="comment" data-template="form&amp;lt;tag&amp;gt;">some long name</a>'
       end
 
     end


### PR DESCRIPTION
This patch moves template of new association record to data-template attribute of link. This means that there won't be any extra blank associated records created. This means people can get rid of those :reject_if => ... on accepted_nested_attributes_for calls.
