### PR TITLE
Compatibility with new jQuery

### DIFF
--- a/lib/generators/cocoon/install/templates/cocoon.js
+++ b/lib/generators/cocoon/install/templates/cocoon.js
@@ -33,8 +33,8 @@ $(document).ready(function() {
       insertionNode = $(this).parent();
     }
 
-    var contentNode = $(new_content);
-    
+    var contentNode = $($('<div />').html(new_content).text());
+
     if (insertionPosition == 'after'){
       insertionNode.after(contentNode);
     } else {


### PR DESCRIPTION
Seems new jQuery no longer unescapes html automatically when creating new element. This patch fixes this by manually unescaping html. I'm not sure if this is the nicest solution, but couldn't find any nicer ones.
