### PR TITLE
Gem runtime dependencies (rails 3.0.9 compatibility)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,13 @@
 source "http://rubygems.org"
 
-gem "rails", "3.0.8"
-#gem "capybara", ">= 0.4.0"
-gem "sqlite3-ruby", :require => "sqlite3"
-
-gem "json_pure"
+gem "rails", "~> 3.0.0"
 
 group :development, :test do
   gem "jeweler"
   gem "rspec-rails", ">= 2.0.0.beta"
   gem "rspec",       ">= 2.0.0.rc"
   gem "actionpack",  ">=3.0.0"
+  gem "sqlite3-ruby", :require => "sqlite3"
   gem "simplecov", :require => false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,6 @@ GEM
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    json_pure (1.5.2)
     mail (2.2.19)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -96,8 +95,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack (>= 3.0.0)
   jeweler
-  json_pure
-  rails (= 3.0.8)
+  rails (~> 3.0.0)
   rspec (>= 2.0.0.rc)
   rspec-rails (>= 2.0.0.beta)
   simplecov

--- a/cocoon.gemspec
+++ b/cocoon.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Nathan Van der Auwera"]
-  s.date = %q{2011-07-21}
+  s.date = %q{2011-07-20}
   s.description = %q{Unobtrusive nested forms handling, using jQuery. Use this and discover cocoon-heaven.}
   s.email = %q{nathan@dixis.com}
   s.extra_rdoc_files = [
@@ -80,34 +80,31 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rails>, ["= 3.0.8"])
-      s.add_runtime_dependency(%q<sqlite3-ruby>, [">= 0"])
-      s.add_runtime_dependency(%q<json_pure>, [">= 0"])
+      s.add_runtime_dependency(%q<rails>, ["~> 3.0.0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<rspec-rails>, [">= 2.0.0.beta"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.0.rc"])
       s.add_development_dependency(%q<actionpack>, [">= 3.0.0"])
+      s.add_development_dependency(%q<sqlite3-ruby>, [">= 0"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.0"])
     else
-      s.add_dependency(%q<rails>, ["= 3.0.8"])
-      s.add_dependency(%q<sqlite3-ruby>, [">= 0"])
-      s.add_dependency(%q<json_pure>, [">= 0"])
+      s.add_dependency(%q<rails>, ["~> 3.0.0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<rspec-rails>, [">= 2.0.0.beta"])
       s.add_dependency(%q<rspec>, [">= 2.0.0.rc"])
       s.add_dependency(%q<actionpack>, [">= 3.0.0"])
+      s.add_dependency(%q<sqlite3-ruby>, [">= 0"])
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 2.0.0"])
     end
   else
-    s.add_dependency(%q<rails>, ["= 3.0.8"])
-    s.add_dependency(%q<sqlite3-ruby>, [">= 0"])
-    s.add_dependency(%q<json_pure>, [">= 0"])
+    s.add_dependency(%q<rails>, ["~> 3.0.0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<rspec-rails>, [">= 2.0.0.beta"])
     s.add_dependency(%q<rspec>, [">= 2.0.0.rc"])
     s.add_dependency(%q<actionpack>, [">= 3.0.0"])
+    s.add_dependency(%q<sqlite3-ruby>, [">= 0"])
     s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 2.0.0"])
   end


### PR DESCRIPTION
The new 1.0.7 gem appears to be working (thanks!), but now I have some new problems. The new gem has these dependencies:

```
json_pure >= 0
rails = 3.0.8
sqlite3-ruby >= 0
```

I had been using cocoon 1.0.5 without issues on Rails 3.0.9. Can we loosen the dependencies to rails ~> 3.0.0?

Also, I think the sqlite3-ruby dependency is only for testing, and not actually a runtime dependency. I couldn't find json_pure being used at all, so I remove that too.
