### PR TITLE
Use this in association-insertion-node 

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
     new_content = new_content.replace(regexp_underscord, newcontent_underscord);
 
     if (insertionNode){
-      insertionNode = $(insertionNode);
+      insertionNode = insertionNode == "this" ? $(this) : $(insertionNode);
     } else {
       insertionNode = $(this).parent();
     }


### PR DESCRIPTION
If somebody want add fields before of the link instead of the parent element, there is no form to select this if it don´t have an "id".

Using association-insertion-node="this" should use just $(this). In application.js now we can assign all add_fields to insert new data just before link.

```
$("a.add_fields").data("association-insertion-position","before");
$("a.add_fields").data("association-insertion-node","this");
```

Great work.
