### PR TITLE
Pass locals to fields partial from the link_to_add_association helper

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -32,9 +32,11 @@ module Cocoon
 
     # :nodoc:
     def render_association(association, f, new_object, render_options={})
+      locals = render_options.delete(:locals)
       method_name = f.respond_to?(:semantic_fields_for) ? :semantic_fields_for : (f.respond_to?(:simple_fields_for) ? :simple_fields_for : :fields_for)
       f.send(method_name, association, new_object, {:child_index => "new_#{association}"}.merge(render_options)) do |builder|
-        render(association.to_s.singularize + "_fields", :f => builder, :dynamic => true)
+        locals = {:f => builder, :dynamic => true}.merge(locals)
+        render(association.to_s.singularize + "_fields", locals)
       end
     end
 


### PR DESCRIPTION
Use the `locals` key in the render options hash to pass local variables to the partial.
