### PR TITLE
Retain relationship to parent object when creating child object using parent.build

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -86,7 +86,7 @@ module Cocoon
     def create_object(f, association)
       assoc      = f.object.class.reflect_on_association(association)
       conditions = assoc.respond_to?(:conditions) ? assoc.conditions.flatten : []
-      new_object = assoc.klass.new(*conditions)
+      f.object.send(association).build(*conditions)
     end
 
     def get_partial_path(partial, association)

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -180,6 +180,12 @@ describe Cocoon do
         result = @tester.create_object(@form_obj, :admin_comments)
         result.author.should == "Admin"
       end
+      
+      it "should create child object and retain reference to parent object" do
+        @post.save! # persist post so that new child has a parent object
+        new_object = @tester.create_object(@form_obj, :admin_comments)
+        new_object.post.should == @post
+      end
     end
 
     context "get_partial_path" do


### PR DESCRIPTION
When creating the child object for fields_for ensure the parent association is retained by using object.assoc.build as opposed to assoc.klass.new

(Test added next to other test explicitly testing #create_object as I couldn't find a describe block specifically for this method)
