### PR TITLE
Use association build methods instead of assoc.klass.new

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -84,9 +84,13 @@ module Cocoon
     # will create new Comment with author "Admin"
 
     def create_object(f, association)
-      assoc      = f.object.class.reflect_on_association(association)
-      conditions = assoc.respond_to?(:conditions) ? assoc.conditions.flatten : []
-      new_object = assoc.klass.new(*conditions)
+      assoc = f.object.class.reflect_on_association(association)
+
+      if assoc.collection?
+        f.object.send(association).build
+      else
+        f.object.send("build_#{association}")
+      end
     end
 
     def get_partial_path(partial, association)

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -175,10 +175,15 @@ describe Cocoon do
       end
     end
 
-    context "association with conditions" do
-      it "should create correct association" do
+    context "create_object" do
+      it "should create correct association with conditions" do
         result = @tester.create_object(@form_obj, :admin_comments)
         result.author.should == "Admin"
+      end
+
+      it "should create correct association for belongs_to associations" do
+        result = @tester.create_object(stub(:object => Comment.new), :post)
+        result.should be_a Post
       end
     end
 

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,3 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :post
+
+  attr_protected :author
 end


### PR DESCRIPTION
I had a model whose relationship had some conditions like the following example:

```
has_many :orphan_posts,
  class_name: 'Post',
  conditions: {parent_id: nil, parent_type: nil}
```

Within the Post model, the parent_id and parent_type are protected attributes and with   `config.active_record.mass_assignment_sanitizer = :strict` set, cocoon's `create_object` method throws mass-assignment errors when it tries to do the `assoc.klass.new(*conditions)`

By using the association build methods, we can use the built-in Rails goodness for handling these attribute accessibility issues.

If you simply do the `attr_protected` on the author attribute of Comment without applying this patch, then you'll see a failure on the "should create correct association" test.

I added an additional test to keep the 100% code coverage, but there's probably room to improve testing this functionality.  If you have ideas for better tests, let me know.  
