### PR TITLE
Added option for a delay on field removal

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -198,6 +198,11 @@ It takes three parameters:
 
 Optionally you could also leave out the name and supply a block that is captured to give the name (if you want to do something more complicated).
 
+If you would like to add a delay to the removal of the node, perhaps to add a fancy animation, you can set 'data-timeout' to a value in milliseconds.
+
+````haml
+= link_to_remove_association 'Remove Suggestion', f, 'data-timeout' => 500
+````
 
 ### Callbacks (upon insert and remove of items)
 

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -54,20 +54,26 @@
 
   $('.remove_fields.dynamic').live('click', function(e) {
     var $this = $(this);
+    var timeout = $this.attr('data-timeout') || 0;
     var trigger_node = $this.closest(".nested-fields").parent();
     trigger_removal_callback(trigger_node);
     e.preventDefault();
-    $this.closest(".nested-fields").remove();
+    setTimeout(function(){
+      $this.closest(".nested-fields").remove();
+    }, timeout);
     trigger_after_removal_callback(trigger_node);
   });
 
   $('.remove_fields.existing').live('click', function(e) {
     var $this = $(this);
+    var timeout = $this.attr('data-timeout') || 0;
     var trigger_node = $this.closest(".nested-fields").parent().parent();
     trigger_removal_callback(trigger_node);
     e.preventDefault();
-    $this.prev("input[type=hidden]").val("1");
-    $this.closest(".nested-fields").hide();
+    setTimeout(function(){
+      $this.prev("input[type=hidden]").val("1");
+      $this.closest(".nested-fields").hide();
+    }, timeout);
     trigger_after_removal_callback(trigger_node);
   });
 


### PR DESCRIPTION
This allows you to set a timeout on link_to_remove_association. The use case would be applying an animation to the element, which would obviously need a specified time to execute before the element is deleted.
