### PR TITLE
Bugfix : Call insertion-callback on the correct container

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -49,7 +49,7 @@
     // code and doesn't force it to be a sibling like after/before does. default: 'before'
     insertionNode[insertionMethod](contentNode);
 
-    $this.parent().trigger('insertion-callback');
+    insertionNode.trigger('insertion-callback');
   });
 
   $('.remove_fields.dynamic').live('click', function(e) {


### PR DESCRIPTION
In case a specific insertion-node is specified (because my link_to_add_association is not contained in this container) , the insertion callback is called on the wrong node (a parent of the div containing the link).
