### PR TITLE
Relative node selection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -173,6 +173,7 @@ It takes four parameters:
 - association: the name of the association (plural) of which a new instance needs to be added (symbol or string).
 - html_options: extra html-options (see `link_to`)
   There are some special options, the first three allow to control the placement of the new link-data:
+  - `data-association-insertion-traversal` : the jquery traversal method to allow node selection relative to the link. `closest`, `next`, `children`, etc. Default: absolute selection
   - `data-association-insertion-node` : the jquery selector of the node
   - `data-association-insertion-method` : jquery method that inserts the new data. `before`, `after`, `append`, `prepend`, etc. Default: `before`
   - `data-association-insertion-position` : old method specifying where to insert new data.
@@ -281,6 +282,18 @@ The `association-insertion-node` will determine where to add it. You can choose 
 
 The `association-insertion-method` will determine where to add it in relation with the node. Any jQuery DOM Manipulation method can be set but we recommend sticking to any of the following: `before`, `after`, `append`, `prepend`. It is unknown at this time what others would do.
 
+The `association-insertion-traversal` will allow node selection to be relative to the link.
+
+For example:
+
+````javascript
+$(document).ready(function() {
+    $("#owner a.add_fields").
+      data("association-insertion-method", 'append').
+      data("association-insertion-traversal", 'closest').
+      data("association-insertion-node", '#parent_table');
+});
+````
 
 ### Partial
 

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -21,6 +21,7 @@
         content               = $this.data('template'),
         insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before';
         insertionNode         = $this.data('association-insertion-node'),
+        insertionTraversal    = $this.data('association-insertion-traversal'),
         regexp_braced         = new RegExp('\\[new_' + assoc + '\\]', 'g'),
         regexp_underscord     = new RegExp('_new_' + assoc + '_', 'g'),
         new_id                = new Date().getTime(),
@@ -37,7 +38,11 @@
     new_content = new_content.replace(regexp_underscord, newcontent_underscord);
 
     if (insertionNode){
-      insertionNode = insertionNode == "this" ? $this : $(insertionNode);
+      if (insertionTraversal){
+        insertionNode = $this[insertionTraversal](insertionNode)
+      } else {
+        insertionNode = insertionNode == "this" ? $this : $(insertionNode);
+      }
     } else {
       insertionNode = $this.parent();
     }


### PR DESCRIPTION
Hi,

Here's a solution for issue #81 I've submitted today.

This allows the use of jquery traversal (`closest`, `next`, `parent`, `children`, etc. everything available here : http://api.jquery.com/category/traversing/tree-traversal/) to select insertion node.

I've personnaly used it for 2 levels table nested forms.

The link to add second level fields has this syntax :

```
link_to_add_association '', f, :filesystems, {data: {:'association-insertion-traversal' => 'closest', :'association-insertion-node' => '#node_filesystems', :'association-insertion-method' => :append}}
```

Which points to the closest  `#node_filesystems` id in the DOM tree.

I haven't found any other solution to do this in your upstream version.

This works perfectly in my case. Nothing changes when `data-association-insertion-traversal` is not used (global selection).

I haven't added specs since it's a Javascript only change.

The readme is updated but my English is not perfect so it's better to review it ;o)

Regards,

Gauthier
