### PR TITLE
Allow created objects to be decorated via a callable option.

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -67,12 +67,18 @@ module Cocoon
         render_options   = html_options.delete(:render_options)
         render_options ||= {}
         override_partial = html_options.delete(:partial)
+        wrap_object = html_options.delete(:wrap_object)
 
         html_options[:class] = [html_options[:class], "add_fields"].compact.join(' ')
         html_options[:'data-association'] = association.to_s.singularize
         html_options[:'data-associations'] = association.to_s.pluralize
 
-        new_object = create_object(f, association)
+        if wrap_object.respond_to?(:call)
+          new_object = wrap_object.call(create_object(f, association))
+        else
+          new_object = create_object(f, association)
+        end
+
         html_options[:'data-association-insertion-template'] = CGI.escapeHTML(render_association(association, f, new_object, render_options, override_partial)).html_safe
 
         link_to(name, '#', html_options )

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -35,6 +35,12 @@ describe Cocoon do
         result = @tester.link_to_add_association('add something', @form_obj, :comments, :partial => "shared/partial")
         result.to_s.should == '<a href="#" class="add_fields" data-association-insertion-template="partiallll" data-association="comment" data-associations="comments">add something</a>'
       end
+
+      it "gives an opportunity to wrap/decorate created objects" do
+        @tester.unstub(:render_association)
+        @tester.should_receive(:render_association).with(anything(), anything(), kind_of(CommentDecorator), anything(), anything()).and_return('partiallll')
+        @tester.link_to_add_association('add something', @form_obj, :comments, :wrap_object => Proc.new {|comment| CommentDecorator.new(comment) })
+      end
     end
 
     context "with a block" do

--- a/spec/dummy/app/decorators/comment_decorator.rb
+++ b/spec/dummy/app/decorators/comment_decorator.rb
@@ -1,0 +1,17 @@
+class CommentDecorator
+  def initialize(comment)
+    @comment = comment
+  end
+
+  def formatted_created_at
+    @comment.created_at.to_formatted_s(:short)
+  end
+
+  def method_missing(method_sym, *args)
+    if @comment.respond_to?(method_sym)
+      @comment.send(method_sym, *args)
+    else
+      super
+    end
+  end
+end


### PR DESCRIPTION
Was running into some issues with nested partials which call methods on decorated objects. (I was using the draper gem.)

I needed associations created through the `#link_to_add_association` method to be decorated. To that end I added an option to pass in a `Proc` or similar callable object to accomplish this. Test should explain the rest.

As decorators are becoming a more common sight these days there may be other people who will find this useful.
