### PR TITLE
Add a before-insertion callback

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -49,6 +49,8 @@
 
     var contentNode = $(new_content);
 
+    insertionNode.trigger('before-insertion-callback');
+
     // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
     // to be called on the node.  allows the insertion node to be the parent of the inserted
     // code and doesn't force it to be a sibling like after/before does. default: 'before'


### PR DESCRIPTION
Add a `before-insertion` callback.  I found myself wanting to attach some behavior to all previously inserted nodes, but not the node about to be inserted.
