### PR TITLE
Ensure inserted "nested-fields" div has a unique id

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -56,7 +56,7 @@
     // code and doesn't force it to be a sibling like after/before does. default: 'before'
     insertionNode[insertionMethod](contentNode);
 	
-	// add a timestamp data field on the inserted div
+	// add a timestamp data attribute to the inserted div
 	contentNode.attr('data-timestamp', new_id);
 
     insertionNode.trigger('cocoon:after-insert');


### PR DESCRIPTION
I had a situation where I needed to be able to reference sections of a form inserted by Cocoon by id. If an id was added to the "nested fields" div, it resulted in invalid html when it was added, as it was not unique.

This change adds a timestamp to the end of the id of the inserted div (only if it has an id), to ensure uniqueness, and to allow the div to be referenced uniquely.
