### PR TITLE
before and after remove triggers not work when fields existing

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -70,7 +70,7 @@
 
   $('.remove_fields.existing').live('click', function(e) {
     var $this = $(this);
-    var trigger_node = $this.closest(".nested-fields").parent().parent();
+    var trigger_node = $this.closest(".nested-fields").parent();
     trigger_before_removal_callback(trigger_node);
     e.preventDefault();
     $this.prev("input[type=hidden]").val("1");


### PR DESCRIPTION
``` javascript
$("#tasks").bind('cocoon:before-remove', function(){
  console.log('123')
});

$("#tasks").bind('cocoon:after-remove', function(){
  console.log('123')
});
```

It work when remove dynamic fields and not work when remove existing. No errors, just triggers not work.
