### PR TITLE
Update app/assets/javascripts/cocoon.js

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -8,7 +8,7 @@
   }
 
 
-  $('.add_fields').live('click', function(e) {
+  $(document).on('click', '.add_fields', function(e) {
     e.preventDefault();
     var $this                 = $(this),
         assoc                 = $this.data('association'),
@@ -55,7 +55,7 @@
   });
 
 
-  $('.remove_fields.dynamic, .remove_fields.existing').live('click', function(e) {
+  $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
     var $this = $(this);
     var node_to_delete = $this.closest(".nested-fields");
     var trigger_node = node_to_delete.parent();


### PR DESCRIPTION
".live()" method replaced by ".on()" (jQuery 1.7+) method

on jQuery 1.7 .live() method is deprecated
on jQuery 1.9 .live() method is removed
