### PR TITLE
Make sure javascript_expansions config option exists

### DIFF
--- a/lib/cocoon.rb
+++ b/lib/cocoon.rb
@@ -4,7 +4,9 @@ module Cocoon
   class Engine < ::Rails::Engine
 
     config.before_initialize do
-      config.action_view.javascript_expansions[:cocoon] = %w(cocoon)
+      if config.action_view.javascript_expansions
+        config.action_view.javascript_expansions[:cocoon] = %w(cocoon)
+      end
     end
 
     # configure our plugin on boot


### PR DESCRIPTION
javascript_expansions config option has been removed in Rails 4 (along with all old asset concat tags), so we have to check for its existence first, like jquery-rails does:
https://github.com/rails/jquery-rails/blob/master/lib/jquery/rails/railtie.rb
