### PR TITLE
Removed 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem "rails", ">=3.0.0"
-  gem "sqlite3-ruby", :require => "sqlite3"
+  gem "sqlite3"
   gem "json_pure"
   gem "jeweler"
   gem "rspec-rails", ">= 2.6.0"

--- a/lib/cocoon.rb
+++ b/lib/cocoon.rb
@@ -3,12 +3,6 @@ require 'cocoon/view_helpers'
 module Cocoon
   class Engine < ::Rails::Engine
 
-    config.before_initialize do
-      if config.action_view.javascript_expansions
-        config.action_view.javascript_expansions[:cocoon] = %w(cocoon)
-      end
-    end
-
     # configure our plugin on boot
     initializer "cocoon.initialize" do |app|
       ActionView::Base.send :include, Cocoon::ViewHelpers


### PR DESCRIPTION
Removed config.action_view.javascript_expansions code, because it seems unnecessary and causes an error in Rails 4. 

Adding to the "config.action_view.javascript_expansions" hash is only necessary if javascript_include_tag(:cocoon) needs to require multiple files, which doesn't appear to be the case.

I also changed gem 'sqlite-ruby' to gem 'sqlite' in order to prevent a warning that I saw when running bundle install for cocoon.
