### PR TITLE
Limit the Travis CI build status badge to the master branch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # cocoon
 
-[![Build Status](https://travis-ci.org/nathanvda/cocoon.png)](https://travis-ci.org/nathanvda/cocoon)
+[![Build Status](https://travis-ci.org/nathanvda/cocoon.png?branch=master)](https://travis-ci.org/nathanvda/cocoon)
 
 Cocoon is a Rails 3 gem that makes it easier to handle nested forms.
 


### PR DESCRIPTION
This will prevent other branches from failing the build on the README.
