### PR TITLE
Turbolinks support

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -2,6 +2,10 @@
 
   var cocoon_element_counter = 0;
 
+  document.addEventListener('page:load', function() {
+    cocoon_element_counter = 0;
+  });
+
   function replace_in_content(content, regexp_str, with_str) {
     reg_exp = new RegExp(regexp_str);
     content.replace(reg_exp, with_str);


### PR DESCRIPTION
Not sure if this is the best way to do it, but I use a window-global property to make sure events on the add and remove fields are only added once.

This patch works without turbolinks enabled, as well.
