### PR TITLE
Changing .bind to .on

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -323,7 +323,7 @@ On insertion or removal the following events are triggered:
 To listen to the events in your JavaScript:
 
 ```javascript
-  $('#container').bind('cocoon:before-insert', function(e, insertedItem) {
+  $('#container').on('cocoon:before-insert', function(e, insertedItem) {
     // ... do something
   });
 ```
@@ -348,32 +348,32 @@ The callbacks can be added as follows:
 ```javascript
 $(document).ready(function() {
     $('#owner')
-      .bind('cocoon:before-insert', function() {
+      .on('cocoon:before-insert', function() {
         $("#owner_from_list").hide();
         $("#owner a.add_fields").hide();
       })
-      .bind('cocoon:after-insert', function() {
+      .on('cocoon:after-insert', function() {
         /* ... do something ... */
       })
-      .bind("cocoon:before-remove", function() {
+      .on("cocoon:before-remove", function() {
         $("#owner_from_list").show();
         $("#owner a.add_fields").show();
       })
-      .bind("cocoon:after-remove", function() {
+      .on("cocoon:after-remove", function() {
         /* e.g. recalculate order of child items */
       });
 
     // example showing manipulating the inserted/removed item
 
     $('#tasks')
-      .bind('cocoon:before-insert', function(e,task_to_be_added) {
+      .on('cocoon:before-insert', function(e,task_to_be_added) {
         task_to_be_added.fadeIn('slow');
       })
-      .bind('cocoon:after-insert', function(e, added_task) {
+      .on('cocoon:after-insert', function(e, added_task) {
         // e.g. set the background of inserted task
         added_task.css("background","red");
       })
-      .bind('cocoon:before-remove', function(e, task) {
+      .on('cocoon:before-remove', function(e, task) {
         // allow some time for the animation to complete
         $(this).data('remove-timeout', 1000);
         task.fadeOut('slow');


### PR DESCRIPTION
As of jQuery 1.7, the .on() and .off() methods are preferred for attaching and removing event handlers.
