### PR TITLE
Add instructions for Strong Parameters/Rails 4 gotcha when deleting nested objects

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,9 +82,9 @@ named `_task_fields.html`.
 
 ### Rails 4/Strong Parameters Gotcha
 
-Cocoon uses an additional parameter `_delete` when rendering multiple instances of the partial form. When a user clicks the link `link_to_remove_association` generates, the partial is hidden with the parameter `_delete` set to `1`.
+Cocoon uses an additional parameter `_destroy` when rendering multiple instances of the partial form. When a user clicks the link `link_to_remove_association` generates, the partial is hidden with the parameter `_destroy` set to `1`.
 
-In order for an association to be deleted on an update, you must explicitly to add `:_delete` to the list of permitted parameters like so:
+In order for an association to be deleted on an update, you must explicitly to add `:_destroy` to the list of permitted parameters like so:
 
 ```ruby
   def project_params


### PR DESCRIPTION
Instructs user to explicitly permit the `_destroy` parameter Cocoon relies on for nested object deletion.

I personally spent about 10 minutes trying to figure out why I couldn't delete my `has_many` nested objects.
