### PR TITLE
Add multiple items on one click

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -2,9 +2,16 @@
 
   var cocoon_element_counter = 0;
 
-  function replace_in_content(content, regexp_str, with_str) {
-    reg_exp = new RegExp(regexp_str);
-    content.replace(reg_exp, with_str);
+  var create_new_id = function() {
+    return (new Date().getTime() + cocoon_element_counter++);
+  }
+  
+  var newcontent_braced = function(id) {
+    return '[' + id + ']$1';
+  }
+  
+  var newcontent_underscord = function(id) {
+    return '_' + id + '_$1';
   }
 
   $(document).on('click', '.add_fields', function(e) {
@@ -16,21 +23,35 @@
         insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before',
         insertionNode         = $this.data('association-insertion-node'),
         insertionTraversal    = $this.data('association-insertion-traversal'),
+        count                 = parseInt($this.data('count'), 10),
         regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
         regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
-        new_id                = new Date().getTime() + cocoon_element_counter++,
-        newcontent_braced     = '[' + new_id + ']',
-        newcontent_underscord = '_' + new_id + '_',
-        new_content           = content.replace(regexp_braced, '[' + new_id + ']$1');
+        new_id                = create_new_id(),
+        new_content           = content.replace(regexp_braced, newcontent_braced(new_id)),
+        new_contents          = [];
 
+    
     if (new_content == content) {
-        regexp_braced     = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
-        regexp_underscord = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
-        new_content       = content.replace(regexp_braced, '[' + new_id + ']$1');
+      regexp_braced     = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
+      regexp_underscord = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
+      new_content       = content.replace(regexp_braced, newcontent_braced(new_id));
     }
 
-    new_content = new_content.replace(regexp_underscord, newcontent_underscord + "$1");
+    new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
+    new_contents = [new_content];
 
+    count = (isNaN(count) ? 1 : Math.max(count, 1));
+    count -= 1;
+    
+    while (count) {
+      new_id      = create_new_id();
+      new_content = content.replace(regexp_braced, newcontent_braced(new_id));
+      new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
+      new_contents.push(new_content);
+      
+      count -= 1;
+    }
+    
     if (insertionNode){
       if (insertionTraversal){
         insertionNode = $this[insertionTraversal](insertionNode);
@@ -41,16 +62,18 @@
       insertionNode = $this.parent();
     }
 
-    var contentNode = $(new_content);
+    for (var i in new_contents) {
+      var contentNode = $(new_contents[i]);
 
-    insertionNode.trigger('cocoon:before-insert', [contentNode]);
+      insertionNode.trigger('cocoon:before-insert', [contentNode]);
 
-    // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
-    // to be called on the node.  allows the insertion node to be the parent of the inserted
-    // code and doesn't force it to be a sibling like after/before does. default: 'before'
-    var addedContent = insertionNode[insertionMethod](contentNode);
+      // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
+      // to be called on the node.  allows the insertion node to be the parent of the inserted
+      // code and doesn't force it to be a sibling like after/before does. default: 'before'
+      var addedContent = insertionNode[insertionMethod](contentNode);
 
-    insertionNode.trigger('cocoon:after-insert', [contentNode]);
+      insertionNode.trigger('cocoon:after-insert', [contentNode]);
+    }
   });
 
   $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -58,6 +58,7 @@ module Cocoon
     #          - *:wrap_object*    : a proc that will allow to wrap your object, especially suited when using
     #                                decorators, or if you want special initialisation   
     #          - *:form_name*      : the parameter for the form in the nested form partial. Default `f`.
+    #          - *:count*          : Count of how many objects will be added on a single click. Default `1`.
     # - *&block*:        see <tt>link_to</tt>
 
     def link_to_add_association(*args, &block)
@@ -78,6 +79,7 @@ module Cocoon
         wrap_object = html_options.delete(:wrap_object)
         force_non_association_create = html_options.delete(:force_non_association_create) || false
         form_parameter_name = html_options.delete(:form_name) || 'f'
+        count = html_options.delete(:count).to_i
 
         html_options[:class] = [html_options[:class], "add_fields"].compact.join(' ')
         html_options[:'data-association'] = association.to_s.singularize
@@ -87,8 +89,10 @@ module Cocoon
         new_object = wrap_object.call(new_object) if wrap_object.respond_to?(:call)
 
         html_options[:'data-association-insertion-template'] = CGI.escapeHTML(render_association(association, f, new_object, form_parameter_name, render_options, override_partial)).html_safe
+        
+        html_options[:'data-count'] = count if count > 0
 
-        link_to(name, '#', html_options )
+        link_to(name, '#', html_options)
       end
     end
 

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -238,6 +238,13 @@ describe Cocoon do
       end
     end
 
+    context 'when adding a count' do
+      before do
+        @html = @tester.link_to_add_association('add something', @form_obj, :comments, { :count => 3 })
+      end
+      it_behaves_like "a correctly rendered add link", { :extra_attributes => { 'data-count' => '3' } }
+    end
+
   end
 
   context "link_to_remove_association" do


### PR DESCRIPTION
I've added the option of a **count** parameter in `#link_to_add_association` helper.
When this is a valid integer, every click on the Add button will create that number of items.

Most of the code is in javascript of course.
I also cleaned the code a little (`newcontent_braced`, `newcontent_underscord` and `create_new_id` functions)

Example that uses a select tag to dynamically change the count (sort of the case in my app):

Markup (Haml):

```
.add-task-items
  = link_to_add_association 'Add', f, :association
  %select
    %option 1
    %option 3
    %option 5
```

Code (JS):

```
$('.add-task-items').on('change', 'select', function({
  count = $(this).val();
  $(this).closest('.add-task-items').find('.add_fields').data('count', count);
});
```

p.s. great gem! :+1:
