### PR TITLE
Add an option to configure the class used to wrap the nested fields. (br...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -332,6 +332,14 @@ It takes three parameters:
 
 Optionally you could also leave out the name and supply a block that is captured to give the name (if you want to do something more complicated).
 
+Optionally, you can add an html option called `wrapper_class` to use a different wrapper div instead of `.nested-class`.
+The class should be added without a preceding dot (`.`).
+
+Example:
+```haml
+= link_to_remove_association('remove this', @form_obj,
+  { wrapper_class: 'my-wrapper-class' })
+```
 
 ### Callbacks (upon insert and remove of items)
 
@@ -412,7 +420,7 @@ This is accomplished by the following line:
 $(this).data('remove-timeout', 1000);
 ```
 
-You could also immediately add this to your view (on the `.nested-fields` container).
+You could also immediately add this to your view, on the `.nested-fields` container (or the `wrapper_class` element you are using).
 
 ### Control the Insertion Behaviour
 
@@ -450,7 +458,7 @@ $(document).ready(function() {
 If no explicit partial name is given, `cocoon` looks for a file named `_<association-object_singular>_fields`.
 To override the default partial use the `:partial` option.
 
-For the JavaScript to behave correctly, the partial should start with a container (e.g. `div`) of class `.nested-fields`.
+For the JavaScript to behave correctly, the partial should start with a container (e.g. `div`) of class `.nested-fields`, or a class of your choice which you can define in the `link_to_remove_association` method.
 
 There is no limit to the amount of nesting, though.
 

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -77,9 +77,10 @@
   });
 
   $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
-    var $this = $(this);
-    var node_to_delete = $this.closest(".nested-fields");
-    var trigger_node = node_to_delete.parent();
+    var $this = $(this),
+        wrapper_class = $this.data('wrapper-class') || 'nested-fields',
+        node_to_delete = $this.closest('.' + wrapper_class),
+        trigger_node = node_to_delete.parent();
 
     e.preventDefault();
 
@@ -98,6 +99,11 @@
     }, timeout);
   });
 
-  $('.remove_fields.existing.destroyed').closest('.nested-fields').hide();
+  $('.remove_fields.existing.destroyed').each(function(i, obj) {
+    var $this = $(this),
+        wrapper_class = $this.data('wrapper-class') || 'nested-fields';
+
+    $this.closest('.' + wrapper_class).hide();
+  });
 
 })(jQuery);

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -31,6 +31,10 @@ module Cocoon
         classes << (is_dynamic ? 'dynamic' : 'existing')
         classes << 'destroyed' if f.object.marked_for_destruction?
         html_options[:class] = [html_options[:class], classes.join(' ')].compact.join(' ')
+
+        wrapper_class = html_options.delete(:wrapper_class)
+        html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
+
         hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
       end
     end

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -314,6 +314,24 @@ describe Cocoon do
         it_behaves_like "a correctly rendered remove link", {text: 'remove some long name', class: 'add_some_class remove_fields dynamic', extra_attributes: {'data-something' => 'bla'}}
       end
     end
+
+    context 'when changing the wrapper class' do
+      context 'should use the default nested-fields class' do
+        before do
+          @html = @tester.link_to_remove_association('remove something', @form_obj)
+        end
+
+        it_behaves_like "a correctly rendered remove link", { }
+      end
+
+      context 'should use the given wrapper class' do
+        before do
+          @html = @tester.link_to_remove_association('remove something', @form_obj, { wrapper_class: 'another-class' })
+        end
+  
+        it_behaves_like "a correctly rendered remove link", { extra_attributes: { 'data-wrapper-class' => 'another-class' } }
+      end
+    end
   end
 
   context "create_object" do


### PR DESCRIPTION
...ought up in issue #178)

My solution was to use the `html_options` parameter of #link_to_remove_association.
If it contains a `wrapper_class` key, it saves that key in the link's data-wrapper-class attribute,
and then uses it in the JS, when trying to remove an item.
