### PR TITLE
Convert data-association-insertion-template to string before escaping to...

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -12,7 +12,7 @@ module Cocoon
     # - *f* : the form this link should be placed in
     # - *html_options*:  html options to be passed to link_to (see <tt>link_to</tt>)
     # - *&block*:        the output of the block will be show in the link, see <tt>link_to</tt>
-    
+
     def link_to_remove_association(*args, &block)
       if block_given?
         f            = args.first
@@ -60,7 +60,7 @@ module Cocoon
     #              - *:locals*     : the locals hash in the :render_options is handed to the partial
     #          - *:partial*        : explicitly override the default partial name
     #          - *:wrap_object*    : a proc that will allow to wrap your object, especially suited when using
-    #                                decorators, or if you want special initialisation   
+    #                                decorators, or if you want special initialisation
     #          - *:form_name*      : the parameter for the form in the nested form partial. Default `f`.
     #          - *:count*          : Count of how many objects will be added on a single click. Default `1`.
     # - *&block*:        see <tt>link_to</tt>
@@ -92,8 +92,8 @@ module Cocoon
         new_object = create_object(f, association, force_non_association_create)
         new_object = wrap_object.call(new_object) if wrap_object.respond_to?(:call)
 
-        html_options[:'data-association-insertion-template'] = CGI.escapeHTML(render_association(association, f, new_object, form_parameter_name, render_options, override_partial)).html_safe
-        
+        html_options[:'data-association-insertion-template'] = CGI.escapeHTML(render_association(association, f, new_object, form_parameter_name, render_options, override_partial).to_str).html_safe
+
         html_options[:'data-count'] = count if count > 0
 
         link_to(name, '#', html_options)


### PR DESCRIPTION
If CGI has been monkeypatched by the https://github.com/brianmario/escape_utils gem, we need to convert the rendered association of link_to_add_association from ActiveSupport::SafeBuffer to String in order for it to be escaped. 
Otherwise, the links will look like this:

![screenshot from 2014-01-21 16 30 50](https://f.cloud.github.com/assets/61476/1961745/e9fabdcc-8279-11e3-9188-05afbb76263b.png)

Please see https://github.com/gsmendoza/cocoon_simple_form_demo/tree/cgi-escape-html-active-support-safe-buffer-bug for a demo of the bug and its fix.
