### PR TITLE
Allow before events to interrupt inserting or removing process.

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -87,7 +87,7 @@
 
     var removeNode = {val: true};
     trigger_node.trigger('cocoon:before-remove', [node_to_delete, removeNode]);
-    if (!removeNode) return;
+    if (!removeNode.val) return;
 
     var timeout = trigger_node.data('remove-timeout') || 0;
 

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -72,9 +72,7 @@
       // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
       // to be called on the node.  allows the insertion node to be the parent of the inserted
       // code and doesn't force it to be a sibling like after/before does. default: 'before'
-      if (insertNode.val) {
-        var addedContent = insertionNode[insertionMethod](contentNode);
-
+      var addedContent = insertionNode[insertionMethod](contentNode);
       insertionNode.trigger('cocoon:after-insert', [contentNode]);
     });
   });

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -64,13 +64,16 @@
 
     $.each(new_contents, function(i, node) {
       var contentNode = $(node);
+      var insertNode = {val: true};
 
-      insertionNode.trigger('cocoon:before-insert', [contentNode]);
+      insertionNode.trigger('cocoon:before-insert', [contentNode, insertNode]);
+      if (!insertNode.val) return;
 
       // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
       // to be called on the node.  allows the insertion node to be the parent of the inserted
       // code and doesn't force it to be a sibling like after/before does. default: 'before'
-      var addedContent = insertionNode[insertionMethod](contentNode);
+      if (insertNode.val) {
+        var addedContent = insertionNode[insertionMethod](contentNode);
 
       insertionNode.trigger('cocoon:after-insert', [contentNode]);
     });
@@ -84,7 +87,9 @@
 
     e.preventDefault();
 
-    trigger_node.trigger('cocoon:before-remove', [node_to_delete]);
+    var removeNode = {val: true};
+    trigger_node.trigger('cocoon:before-remove', [node_to_delete, removeNode]);
+    if (!removeNode) return;
 
     var timeout = trigger_node.data('remove-timeout') || 0;
 


### PR DESCRIPTION
Currently there is no easy way to interrupt cocoon insertion or deletion with, for example, confirmation. This pull request adds this functionality by manipulating an extra object passed to all eventHandlers. With this it is possible for example to write:

```
$(document).bind('cocoon:before-remove', function(e, object, remove) {
     remove.val = remove.val && confirm('Are you sure you want to remove this record?');
}  
```
