### PR TITLE
Added a limit condition that interrupt insertion

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,26 @@
 # Change History / Release Notes
 
+## Version 1.2.5
+
+* fix gem dependencies: we added gems to allow building for rubinius, but those are only
+  needed when developing
+
+## Version 1.2.4
+
+* the wrapper class is now configurable. Before it was assumed to be `nested-fields`.
+  Now it is configurable by handing. See #180. Thanks Yoav Matchulsky.
+* fix build on travis-ci for rubinius (thanks brixen).
+
+## Version 1.2.3
+
+* add license info
+
+## Version 1.2.2
+
+* added option to add multiple items on one click. See #175.
+* cleaned up javascript code. See #171.
+
+
 ## Version 1.2.1
 
 * added a `:form_name` parameter (fixes #153) which allows to use a self-chosen

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -14,6 +14,10 @@
     return '_' + id + '_$1';
   }
 
+  var nested_fields_counter = function(insertionNode, wrapperClass) {
+    return $(insertionNode).children('.' + wrapperClass).length
+  }
+
   $(document).on('click', '.add_fields', function(e) {
     e.preventDefault();
     var $this                 = $(this),
@@ -24,6 +28,8 @@
         insertionNode         = $this.data('association-insertion-node'),
         insertionTraversal    = $this.data('association-insertion-traversal'),
         count                 = parseInt($this.data('count'), 10),
+        limit                 = parseInt($this.data('limit'), 10),
+        wrapperClass          = $this.data('wrapper-class') || 'nested-fields',
         regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
         regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
         new_id                = create_new_id(),
@@ -63,16 +69,20 @@
     }
 
     for (var i in new_contents) {
-      var contentNode = $(new_contents[i]);
+      if(isNaN(limit) || nested_fields_counter(insertionNode, wrapperClass) < limit) {
+        var contentNode = $(new_contents[i]);
 
-      insertionNode.trigger('cocoon:before-insert', [contentNode]);
+        insertionNode.trigger('cocoon:before-insert', [contentNode]);
 
-      // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
-      // to be called on the node.  allows the insertion node to be the parent of the inserted
-      // code and doesn't force it to be a sibling like after/before does. default: 'before'
-      var addedContent = insertionNode[insertionMethod](contentNode);
+        // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
+        // to be called on the node.  allows the insertion node to be the parent of the inserted
+        // code and doesn't force it to be a sibling like after/before does. default: 'before'
+        var addedContent = insertionNode[insertionMethod](contentNode);
 
-      insertionNode.trigger('cocoon:after-insert', [contentNode]);
+        insertionNode.trigger('cocoon:after-insert', [contentNode]);
+      } else {
+        insertionNode.trigger('cocoon:limit-reached', [contentNode]);
+      }
     }
   });
 

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -84,6 +84,7 @@ module Cocoon
         force_non_association_create = html_options.delete(:force_non_association_create) || false
         form_parameter_name = html_options.delete(:form_name) || 'f'
         count = html_options.delete(:count).to_i
+        limit = html_options.delete(:limit).to_i
 
         html_options[:class] = [html_options[:class], "add_fields"].compact.join(' ')
         html_options[:'data-association'] = association.to_s.singularize
@@ -91,10 +92,13 @@ module Cocoon
 
         new_object = create_object(f, association, force_non_association_create)
         new_object = wrap_object.call(new_object) if wrap_object.respond_to?(:call)
-
-        html_options[:'data-association-insertion-template'] = CGI.escapeHTML(render_association(association, f, new_object, form_parameter_name, render_options, override_partial)).html_safe
+        
+        content = CGI.escapeHTML(render_association(association, f, new_object, form_parameter_name, render_options, override_partial)).html_safe
+        html_options[:'data-association-insertion-template'] = content
+        html_options[:'data-wrapper-class'] = /(?<=class=["'])[^"^']*(?=["'])/.match(content)
         
         html_options[:'data-count'] = count if count > 0
+        html_options[:'data-limit'] = limit if limit > 0
 
         link_to(name, '#', html_options)
       end

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -245,6 +245,12 @@ describe Cocoon do
       it_behaves_like "a correctly rendered add link", { :extra_attributes => { 'data-count' => '3' } }
     end
 
+    context 'when adding a limit' do
+      before do
+        @html = @tester.link_to_add_association('add something', @form_obj, :comments, { :limit => 3 })
+      end
+      it_behaves_like "a correctly rendered add link", { :extra_attributes => { 'data-limit' => '3' } }
+    end
   end
 
   context "link_to_remove_association" do


### PR DESCRIPTION
As mentioned in https://github.com/nathanvda/cocoon/issues/194, I made a contribution that consider a limit condition in parameter as:

``` ruby
link_to_add_association 'Add Association', f, :associations, limit: 3
```

and interrupt the insertion the nested associations in that node and also trigger the event `cocoon:limit-reached`.
