### PR TITLE
Allow to use with simple arrays without AR

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -105,7 +105,8 @@ module Cocoon
     # will create new Comment with author "Admin"
 
     def create_object(f, association, force_non_association_create=false)
-      assoc = f.object.class.reflect_on_association(association)
+      klass = f.object.class
+      assoc = klass.respond_to?(:reflect_on_association) ? klass.reflect_on_association(association) : nil
 
       assoc ? create_object_on_association(f, association, assoc, force_non_association_create) : create_object_on_non_association(f, association)
     end

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -356,8 +356,10 @@ describe Cocoon do
       comment.post.should be_nil
     end
 
-    it "raises an error if cannot reflect on association" do
-      expect { @tester.create_object(double(:object => Comment.new), :not_existing) }.to raise_error /association/i
+    it "creates an object if cannot reflect on association" do
+      object = double("AnyNonActiveRecordObject")
+      object.should_receive(:build_non_reflectable).and_return 'custom'
+      @tester.create_object(double(:object => object), :non_reflectable).should == 'custom'
     end
 
     it "creates an association if object responds to 'build_association' as singular" do


### PR DESCRIPTION
This complements already accepted PR I sent a while ago
https://github.com/nathanvda/cocoon/pull/90

That PR allowed using cocoon on ActiveRecord models
with nested Array items.
But still the main form object had to be ActiveRecord.

This commit removes that restriction and allows
using cocoon with plain ActiveModel-compliant objects
(including the object for the main form).

This has been requested in the issue below but went unnoticed
https://github.com/nathanvda/cocoon/issues/141

Usage example (model only side)

``` ruby

class User
  include ActiveAttr::Model
  attribute :email
end

class Company
  include ActiveAttr::Model

  def users
    @users ||= []
  end

  # This will allow setting the attributes from `fields_for` rails helper
  # when the form will be posted
  def users_attributes=(attrs)
    # update the users array...
  end

  # cocoon uses this method to render the template
  def build_user
    User.new # blank state for new template
  end
end

```

@nathanvda, I would appreciate if you could merge this in and maybe release the gem when possible so that I can make use of it in my project.
