### PR TITLE
README Clarification for has_one

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -307,6 +307,8 @@ E.g.
 In normal cases we create a new nested object using the association relation itself. This is the cleanest way to create
 a new nested object.
 
+_Note_ If you are using `link_to_add_association` with a has_one association, the existing associated object will be destroyed whenever this method is called for that association. 
+
 This used to have a side-effect: for each call of `link_to_add_association` a new element was added to the association.
 This is no longer the case.
 


### PR DESCRIPTION
A small change to the README save others some troubleshooting time. For reasons too complicated to explain here I need to allow users to delete and create a record with a 'has_one' association. 

The destruction of the associated object is expected as per has_one#association= documentation (excerpted):

Assigns the associate object, extracts the primary key, sets it as the foreign key, and saves the associate object. To avoid database inconsistencies, permanently deletes an existing associated object when assigning a new one, even if the new one isn't saved to database.
