### PR TITLE
Accesing indirect ancestors of the given node while inserting new nodes.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -216,7 +216,9 @@ This should be called within the form builder.
 - html_options: extra html-options (see [`link_to`](http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
   There are some special options, the first three allow to control the placement of the new link-data:
   - `data-association-insertion-traversal` : the jquery traversal method to allow node selection relative to the link. `closest`, `next`, `children`, etc. Default: absolute selection
+  - `data-association-insertion-traversal-down` : the jquery traversal method to allow node selection in downward direction to reach indirect ancestors.
   - `data-association-insertion-node` : the jquery selector of the node
+  - `data-association-insertion-node-down` : the jquery selector of the final node if using 'data-association-insertion-traversal-down' method. 
   - `data-association-insertion-method` : jquery method that inserts the new data. `before`, `after`, `append`, `prepend`, etc. Default: `before`
   - `data-association-insertion-position` : old method specifying where to insert new data.
       - this setting still works but `data-association-insertion-method` takes precedence. may be removed in a future version.

--- a/README.markdown
+++ b/README.markdown
@@ -216,7 +216,7 @@ This should be called within the form builder.
 - html_options: extra html-options (see [`link_to`](http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
   There are some special options, the first three allow to control the placement of the new link-data:
   - `data-association-insertion-traversal` : the jquery traversal method to allow node selection relative to the link. `closest`, `next`, `children`, etc. Default: absolute selection
-  - `data-association-insertion-traversal-down` : the jquery traversal method to allow node selection in downward direction to reach indirect ancestors.
+  - `data-association-insertion-traversal-down` : the jquery traversal method to allow node selection in downward direction to reach indirect ancestors.  This is optional but if used, it must be in conjunction with 'data-association-insertion-traversal`' .
   - `data-association-insertion-node` : the jquery selector of the node
   - `data-association-insertion-node-down` : the jquery selector of the final node if using 'data-association-insertion-traversal-down' method. 
   - `data-association-insertion-method` : jquery method that inserts the new data. `before`, `after`, `append`, `prepend`, etc. Default: `before`

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -22,7 +22,9 @@
         content               = $this.data('association-insertion-template'),
         insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before',
         insertionNode         = $this.data('association-insertion-node'),
+		insertionNodeDown     = $this.data('association-insertion-node-down'),
         insertionTraversal    = $this.data('association-insertion-traversal'),
+		insertionTraversalDown= $this.data('association-insertion-traversal-down'),
         count                 = parseInt($this.data('count'), 10),
         regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
         regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
@@ -52,9 +54,16 @@
       count -= 1;
     }
 
+	
     if (insertionNode){
       if (insertionTraversal){
+		// provides a way to move both up and down the DOM tree - Added by Sriharsha
+          if(insertionTraversalDown && insertionNodeDown){
+              insertionNode = $this[insertionTraversal](insertionNode)[insertionTraversalDown](insertionNodeDown);
+          }
+          else{
         insertionNode = $this[insertionTraversal](insertionNode);
+          }
       } else {
         insertionNode = insertionNode == "this" ? $this : $(insertionNode);
       }


### PR DESCRIPTION
Added methods to access indirect ancestors of the starting node. This fork should compliment the original 'data-association-insertion-node' and 'data-association-insertion-traversal' which are used to relatively identify the target nodes during insert of nodes.
Eg:

``` haml
.grandfather
  .aunt
    This is a repeating trend
  .mother
    %a.start
      This is a repeating trend
.grandfather
  .aunt
    I want this
  .mother
    %a.start
      I am here. This is 'link to add association class'
```
