### PR TITLE
Drop support for Ruby 1.9 and add support for Ruby 2.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 script: "bundle exec rake"
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1
   - rbx-2
 gemfile:
   - gemfiles/Gemfile.rails-3.2.13


### PR DESCRIPTION
[Support for Ruby version 1.9.3 will end on February 23, 2015.](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)
