### PR TITLE
Specify null: false for timestamps in dummy app.

### DIFF
--- a/spec/dummy/db/migrate/20110306212208_create_posts.rb
+++ b/spec/dummy/db/migrate/20110306212208_create_posts.rb
@@ -4,7 +4,7 @@ class CreatePosts < ActiveRecord::Migration
       t.string :title
       t.text :body
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 

--- a/spec/dummy/db/migrate/20110306212250_create_comments.rb
+++ b/spec/dummy/db/migrate/20110306212250_create_comments.rb
@@ -5,7 +5,7 @@ class CreateComments < ActiveRecord::Migration
       t.string :author
       t.integer :post_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 

--- a/spec/dummy/db/migrate/20110420222224_create_people.rb
+++ b/spec/dummy/db/migrate/20110420222224_create_people.rb
@@ -5,7 +5,7 @@ class CreatePeople < ActiveRecord::Migration
       t.string :description
       t.integer :post_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -8,23 +9,31 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110306212250) do
+ActiveRecord::Schema.define(version: 20110420222224) do
 
-  create_table "comments", :force => true do |t|
+  create_table "comments", force: :cascade do |t|
     t.text     "body"
     t.string   "author"
     t.integer  "post_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "posts", :force => true do |t|
+  create_table "people", force: :cascade do |t|
+    t.string   "name"
+    t.string   "description"
+    t.integer  "post_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
     t.string   "title"
     t.text     "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end


### PR DESCRIPTION
To avoid deprecation messages.

I can change hash syntax back to hash rockets if Ruby 1.8 is still supported. `schema.rb` file was generated by Rails 4.2.
