### PR TITLE
Insertion node default README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -216,7 +216,7 @@ This should be called within the form builder.
 - html_options: extra html-options (see [`link_to`](http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
   There are some special options, the first three allow to control the placement of the new link-data:
   - `data-association-insertion-traversal` : the jquery traversal method to allow node selection relative to the link. `closest`, `next`, `children`, etc. Default: absolute selection
-  - `data-association-insertion-node` : the jquery selector of the node
+  - `data-association-insertion-node` : the jquery selector of the node. Default: parent node
   - `data-association-insertion-method` : jquery method that inserts the new data. `before`, `after`, `append`, `prepend`, etc. Default: `before`
   - `data-association-insertion-position` : old method specifying where to insert new data.
       - this setting still works but `data-association-insertion-method` takes precedence. may be removed in a future version.


### PR DESCRIPTION
I haven't realised at glance what is the default value for `data-association-insertion-node` data attributes. So maybe it will be helpful and consistent (with other data attributes defaults) to specify such one.