### PR TITLE
Update insertionNode if changed on before-insert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem "rails", ">=4.0.0"
-  gem "sqlite3", "1.3.8"
+  gem "sqlite3", "1.3.10"
   gem "json_pure"
   gem "jeweler"
   gem "rspec-rails", "~> 3.0.0"

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -53,6 +53,7 @@
     }
 
     if (insertionNode){
+      var nodeSelector = insertionNode;
       if (insertionTraversal){
         insertionNode = $this[insertionTraversal](insertionNode);
       } else {
@@ -70,6 +71,11 @@
       // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
       // to be called on the node.  allows the insertion node to be the parent of the inserted
       // code and doesn't force it to be a sibling like after/before does. default: 'before'
+
+      if (nodeSelector !== undefined && $(nodeSelector).attr('id') !== insertionNode.attr('id')) {
+        insertionNode = $(nodeSelector);
+      }
+
       var addedContent = insertionNode[insertionMethod](contentNode);
 
       insertionNode.trigger('cocoon:after-insert', [contentNode]);


### PR DESCRIPTION
Hello,

I was with the following case:

I wanted to insert the content of the new child inside a container that was created in the "before-insert" hook. As the insertionNode is defined before the hook, it was not catching the right element.

Ex: '.some-selector:last-of-type'

I don't know if this is the best way to solve this, but worked as i expected.

If you find interesting adding this, this is what I modified.
