### PR TITLE
Check form class to render partial

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -43,7 +43,7 @@ module Cocoon
     def render_association(association, f, new_object, form_name, render_options={}, custom_partial=nil)
       partial = get_partial_path(custom_partial, association)
       locals =  render_options.delete(:locals) || {}
-      method_name = f.respond_to?(:semantic_fields_for) ? :semantic_fields_for : (f.respond_to?(:simple_fields_for) ? :simple_fields_for : :fields_for)
+      method_name = f.class.ancestors.include?('SimpleForm::Builder') ? :simple_fields_for : (f.class.ancestors.include?('Formtastic::FormBuilder') ? :semantic_fields_for : :fields_for)
       f.send(method_name, association, new_object, {:child_index => "new_#{association}"}.merge(render_options)) do |builder|
         partial_options = {form_name.to_sym => builder, :dynamic => true}.merge(locals)
         render(partial, partial_options)

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -213,6 +213,7 @@ describe Cocoon do
       end
       context "calls semantic_fields_for and not fields_for" do
         before do
+          allow(@form_obj).to receive_message_chain(:class, :ancestors) { 'Formtastic::FormBuilder' }
           expect(@form_obj).to receive(:semantic_fields_for)
           expect(@form_obj).to receive(:fields_for).never
           @html = @tester.link_to_add_association('add something', @form_obj, :people)
@@ -230,6 +231,7 @@ describe Cocoon do
       end
       context "calls simple_fields_for and not fields_for" do
         before do
+          allow(@form_obj).to receive_message_chain(:class, :ancestors) { 'SimpleForm::Builder' }
           expect(@form_obj).to receive(:simple_fields_for)
           expect(@form_obj).to receive(:fields_for).never
           @html = @tester.link_to_add_association('add something', @form_obj, :people)


### PR DESCRIPTION
Check form class rather than whether it responds to form methods to more accurately render add association form partials.  Resolves #291 