### PR TITLE
Allow to pass a block to the render method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -228,6 +228,7 @@ This should be called within the form builder.
   - `form_name` : the name of the form parameter in your nested partial. By default this is `f`.
 
 Optionally, you can omit the name and supply a block that is captured to render the link body (if you want to do something more complicated).
+Otherwise, if the name is present, the block will be passed to `render`, so you can `yield` anything directly from the partial. It can help you to reuse your partials.
 
 #### :render_options
 Inside the `html_options` you can add an option `:render_options`, and the containing hash will be handed down to the form builder for the inserted

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -136,6 +136,20 @@ describe Cocoon do
 
         it_behaves_like "a correctly rendered add link", {class: 'floppy disk add_fields', template: "partiallll", text: 'some long name'}
       end
+
+      context "and three main arguments present" do
+        before do
+          @tester = TestClass.new
+          expect(@form_obj).to receive(:fields_for) { | association, new_object, options_hash, &block| block.call }
+          expect(@tester).to receive(:render) { |partial, partial_options, &block| "Hello, #{block.call("was here")}" }
+
+          @html = @tester.link_to_add_association("A link", @form_obj, :comments) do |yielded_arg|
+            "Yield #{yielded_arg}!"
+          end
+        end
+
+        it_behaves_like "a correctly rendered add link", { text: "A link", template: "Hello, Yield was here!" }
+      end
     end
 
     context "with an irregular plural" do
@@ -330,7 +344,7 @@ describe Cocoon do
         before do
           @html = @tester.link_to_remove_association('remove something', @form_obj, { wrapper_class: 'another-class' })
         end
-  
+
         it_behaves_like "a correctly rendered remove link", { extra_attributes: { 'data-wrapper-class' => 'another-class' } }
       end
     end


### PR DESCRIPTION
There is a handy trick in `ActionView`, which I use a lot: one can pass a block to the rendered partial. It provides a simple way of building partials and helpers. For example, one can make a `FormBuilder` extension around `cocoon`, which will work as simple as this:

``` ruby
= f.cocoon_nested_fields_for :awards do |ff|
  = ff.input :title
  = ff.input :content
```

But since `block` in `cocoon` is rendered within a `link_to`, it was impossible to use this little trick till the moment. What I propose is to treat `block` argument differently depending on arguments: if `name` was passed to `link_to_add_association`, than block is passed to `render`, otherwise it is captured for `link_to` needs.
