### PR TITLE
fixes bug introduced in #292 look up in array of strings instead of classes

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -45,7 +45,8 @@ module Cocoon
     def render_association(association, f, new_object, form_name, render_options={}, custom_partial=nil)
       partial = get_partial_path(custom_partial, association)
       locals =  render_options.delete(:locals) || {}
-      method_name = f.class.ancestors.include?('SimpleForm::Builder') ? :simple_fields_for : (f.class.ancestors.include?('Formtastic::FormBuilder') ? :semantic_fields_for : :fields_for)
+      ancestors = f.class.ancestors.map{|c| c.to_s}
+      method_name = ancestors.include?('SimpleForm::FormBuilder') ? :simple_fields_for : (ancestors.include?('Formtastic::FormBuilder') ? :semantic_fields_for : :fields_for)
       f.send(method_name, association, new_object, {:child_index => "new_#{association}"}.merge(render_options)) do |builder|
         partial_options = {form_name.to_sym => builder, :dynamic => true}.merge(locals)
         render(partial, partial_options)

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -235,7 +235,7 @@ describe Cocoon do
       end
       context "calls semantic_fields_for and not fields_for" do
         before do
-          allow(@form_obj).to receive_message_chain(:class, :ancestors) { 'Formtastic::FormBuilder' }
+          allow(@form_obj).to receive_message_chain(:class, :ancestors) { ['Formtastic::FormBuilder'] }
           expect(@form_obj).to receive(:semantic_fields_for)
           expect(@form_obj).to receive(:fields_for).never
           @html = @tester.link_to_add_association('add something', @form_obj, :people)
@@ -253,7 +253,7 @@ describe Cocoon do
       end
       context "calls simple_fields_for and not fields_for" do
         before do
-          allow(@form_obj).to receive_message_chain(:class, :ancestors) { 'SimpleForm::Builder' }
+          allow(@form_obj).to receive_message_chain(:class, :ancestors) { ['SimpleForm::FormBuilder'] }
           expect(@form_obj).to receive(:simple_fields_for)
           expect(@form_obj).to receive(:fields_for).never
           @html = @tester.link_to_add_association('add something', @form_obj, :people)


### PR DESCRIPTION
SimpleForm detection was using the wrong class name, and the ancestor array needed to be an array of strings.