### PR TITLE
Fix test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem "actionpack",  ">=4.0.0"
   gem "simplecov", :require => false
   gem "rack", "< 2"
+  gem "mime-types", "< 3"
 
   gem 'nokogiri'
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem "rspec",       "~> 3.0.0"
   gem "actionpack",  ">=4.0.0"
   gem "simplecov", :require => false
+  gem "rack", "< 2"
 
   gem 'nokogiri'
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ group :development, :test do
     gem 'psych'
     gem 'racc'
     gem 'rubinius-developer_tools'
+    gem 'rubinius-coverage', '< 2.1'
+    gem 'rubysl-coverage', '< 2.1'
   end
 
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 group :development, :test do
   gem "rails", ">=4.0.0"
   gem "sqlite3", "1.3.8"
-  gem "json_pure"
+  gem "json_pure", "< 2"
   gem "jeweler"
   gem "rspec-rails", "~> 3.0.0"
   gem "rspec",       "~> 3.0.0"

--- a/gemfiles/Gemfile.rails-3.2.13
+++ b/gemfiles/Gemfile.rails-3.2.13
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 group :development, :test do
   gem "rails", "~> 3.2.0"
   gem "sqlite3", "1.3.8"
-  gem "json_pure"
+  gem "json_pure", "< 2"
   gem "jeweler"
   gem "rspec-rails", "~> 3.0.0"
   gem "rspec",       "~> 3.0.0"

--- a/gemfiles/Gemfile.rails-3.2.13
+++ b/gemfiles/Gemfile.rails-3.2.13
@@ -24,6 +24,8 @@ platforms :rbx do
   gem 'psych'
   gem 'racc'
   gem 'rubinius-developer_tools'
+  gem 'rubinius-coverage', '< 2.1'
+  gem 'rubysl-coverage', '< 2.1'
 end
 
 # To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)

--- a/gemfiles/Gemfile.rails-3.2.13
+++ b/gemfiles/Gemfile.rails-3.2.13
@@ -11,6 +11,7 @@ group :development, :test do
   gem "actionpack",  "~> 3.2.0"
   gem "simplecov", :require => false
   gem "rack", "< 2"
+  gem "mime-types", "< 3"
 
   gem 'nokogiri'
 

--- a/gemfiles/Gemfile.rails-3.2.13
+++ b/gemfiles/Gemfile.rails-3.2.13
@@ -10,6 +10,7 @@ group :development, :test do
   gem "rspec",       "~> 3.0.0"
   gem "actionpack",  "~> 3.2.0"
   gem "simplecov", :require => false
+  gem "rack", "< 2"
 
   gem 'nokogiri'
 


### PR DESCRIPTION
Tests will fail even master branch because some gems released newer version and dropped support for old rubies.

By the way, [Ruby < 2.1](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1) and [Rails < 4.2](http://guides.rubyonrails.org/maintenance_policy.html)  are no longer supported.
Now is the time to drop old Ruby/Rails and publish new version (cocoon 2.0) I think :bulb: 
