### PR TITLE
Fix for issue #402 - Change text links to buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,13 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem "rails", ">=4.0.0"
-  gem "sqlite3", "1.3.8"
+  gem "sqlite3"
   gem "json_pure"
   gem "jeweler"
-  gem "rspec-rails", "~> 3.0.0"
-  gem "rspec",       "~> 3.0.0"
-  gem "actionpack",  ">=4.0.0"
+  gem "rspec-rails"
+  gem "rspec"
+  gem "rack", "< 2"
+  gem "actionpack"
   gem "simplecov", :require => false
 
   gem 'nokogiri'

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -99,7 +99,7 @@ module Cocoon
 
         html_options[:'data-count'] = count if count > 0
 
-        link_to(name, '#', html_options)
+        button_tag(name, html_options)
       end
     end
 

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -37,7 +37,7 @@ module Cocoon
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
 
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + button_tag(name, html_options)
+        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
       end
     end
 
@@ -99,7 +99,7 @@ module Cocoon
 
         html_options[:'data-count'] = count if count > 0
 
-        button_tag(name, html_options)
+        link_to(name, '#', html_options)
       end
     end
 

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -37,7 +37,7 @@ module Cocoon
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
 
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + button_tag(name, '#', html_options)
+        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + button_tag(name, html_options)
       end
     end
 

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -14,31 +14,11 @@ module Cocoon
     # - *&block*:        the output of the block will be show in the link, see <tt>link_to</tt>
 
     def link_to_remove_association(*args, &block)
-      if block_given?
-        link_to_remove_association(capture(&block), *args)
-      elsif args.first.respond_to?(:object)
-        form = args.first
-        association = form.object.class.to_s.tableize
-        name = I18n.translate("cocoon.#{association}.remove", default: I18n.translate('cocoon.defaults.remove'))
+      remove_association('link_to', *args, &block)
+    end
 
-        link_to_remove_association(name, *args)
-      else
-        name, f, html_options = *args
-        html_options ||= {}
-
-        is_dynamic = f.object.new_record?
-
-        classes = []
-        classes << "remove_fields"
-        classes << (is_dynamic ? 'dynamic' : 'existing')
-        classes << 'destroyed' if f.object.marked_for_destruction?
-        html_options[:class] = [html_options[:class], classes.join(' ')].compact.join(' ')
-
-        wrapper_class = html_options.delete(:wrapper_class)
-        html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
-
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
-      end
+    def button_to_remove_association(*args, &block)
+      remove_association('button_to', *args, &block)
     end
 
     # :nodoc:
@@ -69,6 +49,61 @@ module Cocoon
     # - *&block*:        see <tt>link_to</tt>
 
     def link_to_add_association(*args, &block)
+      add_association('link_to', *args, &block)
+    end
+
+    def button_to_add_association(*args, &block)
+      add_association('button_to', *args, &block)
+    end
+
+    # creates new association object with its conditions, like
+    # `` has_many :admin_comments, class_name: "Comment", conditions: { author: "Admin" }
+    # will create new Comment with author "Admin"
+
+    def create_object(f, association, force_non_association_create=false)
+      assoc = f.object.class.reflect_on_association(association)
+
+      assoc ? create_object_on_association(f, association, assoc, force_non_association_create) : create_object_on_non_association(f, association)
+    end
+
+    def get_partial_path(partial, association)
+      partial ? partial : association.to_s.singularize + "_fields"
+    end
+
+    private
+
+    def remove_association(link_type, *args, &block)
+      if block_given?
+        link_to_remove_association(capture(&block), *args)
+      elsif args.first.respond_to?(:object)
+        form = args.first
+        association = form.object.class.to_s.tableize
+        name = I18n.translate("cocoon.#{association}.remove", default: I18n.translate('cocoon.defaults.remove'))
+
+        link_to_remove_association(name, *args)
+      else
+        name, f, html_options = *args
+        html_options ||= {}
+
+        is_dynamic = f.object.new_record?
+
+        classes = []
+        classes << "remove_fields"
+        classes << (is_dynamic ? 'dynamic' : 'existing')
+        classes << 'destroyed' if f.object.marked_for_destruction?
+        html_options[:class] = [html_options[:class], classes.join(' ')].compact.join(' ')
+
+        wrapper_class = html_options.delete(:wrapper_class)
+        html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
+
+        links = {:button_to => button_tag(name, html_options),
+          :link_to => link_to(name, '#', html_options)}
+
+        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + links[link_type.to_sym]
+      end
+    end
+
+    def add_association(link_type, *args, &block)
       if block_given?
         link_to_add_association(capture(&block), *args)
       elsif args.first.respond_to?(:object)
@@ -99,25 +134,12 @@ module Cocoon
 
         html_options[:'data-count'] = count if count > 0
 
-        link_to(name, '#', html_options)
+        links = {:button_to => button_tag(name, html_options),
+          :link_to => link_to(name, '#', html_options)}
+
+        links[link_type.to_sym]
       end
     end
-
-    # creates new association object with its conditions, like
-    # `` has_many :admin_comments, class_name: "Comment", conditions: { author: "Admin" }
-    # will create new Comment with author "Admin"
-
-    def create_object(f, association, force_non_association_create=false)
-      assoc = f.object.class.reflect_on_association(association)
-
-      assoc ? create_object_on_association(f, association, assoc, force_non_association_create) : create_object_on_non_association(f, association)
-    end
-
-    def get_partial_path(partial, association)
-      partial ? partial : association.to_s.singularize + "_fields"
-    end
-
-    private
 
     def create_object_on_non_association(f, association)
       builder_method = %W{build_#{association} build_#{association.to_s.singularize}}.select { |m| f.object.respond_to?(m) }.first

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -37,7 +37,7 @@ module Cocoon
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
 
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
+        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + button_tag(name, '#', html_options)
       end
     end
 

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -303,7 +303,7 @@ describe Cocoon do
         before do
           args = ['remove something', @form_obj]
           @html = @tester.link_to_remove_association(*args)
-          @button_html = @tester.link_to_remove_association(*args)
+          @button_html = @tester.button_to_remove_association(*args)
         end
 
         it "is rendered inside a input element" do
@@ -323,6 +323,7 @@ describe Cocoon do
             I18n.backend.store_translations(:en, :cocoon => { :posts => { :remove => 'Remove post' } })
 
             @html = @tester.link_to_remove_association(@form_obj)
+            @button_html = @tester.button_to_remove_association(@form_obj)
           end
 
           it_behaves_like "a correctly rendered remove link", { text: 'Remove post' }
@@ -333,6 +334,7 @@ describe Cocoon do
             I18n.backend.store_translations(:en, :cocoon => { :defaults => { :remove => 'Remove' } })
 
             @html = @tester.link_to_remove_association(@form_obj)
+            @button_html = @tester.button_to_remove_association(@form_obj)
           end
 
           it_behaves_like "a correctly rendered remove link", { text: 'Remove' }
@@ -342,6 +344,7 @@ describe Cocoon do
       context "accepts html options and pass them to link_to" do
         before do
           @html = @tester.link_to_remove_association('remove something', @form_obj, {:class => 'add_some_class', :'data-something' => 'bla'})
+          @button_html = @tester.button_to_remove_association('remove something', @form_obj, {:class => 'add_some_class', :'data-something' => 'bla'})
         end
         it_behaves_like "a correctly rendered remove link", {class: 'add_some_class remove_fields dynamic', extra_attributes: {'data-something' => 'bla'}}
       end
@@ -356,10 +359,19 @@ describe Cocoon do
         @post_marked_for_destruction.mark_for_destruction
         @form_obj_destroyed = double(:object => @post_marked_for_destruction, :object_name => @post_marked_for_destruction.class.name)
         @html = @tester.link_to_remove_association('remove something', @form_obj_destroyed)
+        @button_html = @tester.button_to_remove_association('remove something', @form_obj_destroyed)
       end
 
-      it "is rendered inside a input element" do
+      it "is rendered as link inside a input element" do
         doc = Nokogiri::HTML(@html)
+        removed = doc.at('input')
+        expect(removed.attribute('id').value).to eq("Post__destroy")
+        expect(removed.attribute('name').value).to eq("Post[_destroy]")
+        expect(removed.attribute('value').value).to eq("true")
+      end
+
+      it "is rendered as button inside a input element" do
+        doc = Nokogiri::HTML(@button_html)
         removed = doc.at('input')
         expect(removed.attribute('id').value).to eq("Post__destroy")
         expect(removed.attribute('name').value).to eq("Post[_destroy]")
@@ -372,18 +384,16 @@ describe Cocoon do
     context "with a block" do
       context "the block gives the name" do
         before do
-          @html = @tester.link_to_remove_association(@form_obj) do
-            "remove some long name"
-          end
+          @html = @tester.link_to_remove_association(@form_obj) { "remove some long name" }
+          @button_html = @tester.button_to_remove_association(@form_obj) { "remove some long name" }
         end
         it_behaves_like "a correctly rendered remove link", {text: 'remove some long name'}
       end
 
       context "accepts html options and pass them to link_to" do
         before do
-          @html = @tester.link_to_remove_association(@form_obj, {:class => 'add_some_class', :'data-something' => 'bla'}) do
-            "remove some long name"
-          end
+          @html = @tester.link_to_remove_association(@form_obj, {:class => 'add_some_class', :'data-something' => 'bla'}) { "remove some long name" }
+          @button_html = @tester.button_to_remove_association(@form_obj, {:class => 'add_some_class', :'data-something' => 'bla'}) { "remove some long name" }
         end
         it_behaves_like "a correctly rendered remove link", {text: 'remove some long name', class: 'add_some_class remove_fields dynamic', extra_attributes: {'data-something' => 'bla'}}
       end
@@ -392,7 +402,9 @@ describe Cocoon do
     context 'when changing the wrapper class' do
       context 'should use the default nested-fields class' do
         before do
-          @html = @tester.link_to_remove_association('remove something', @form_obj)
+          args = ['remove something', @form_obj]
+          @html = @tester.link_to_remove_association(*args)
+          @button_html = @tester.button_to_remove_association(*args)
         end
 
         it_behaves_like "a correctly rendered remove link", { }
@@ -401,6 +413,7 @@ describe Cocoon do
       context 'should use the given wrapper class' do
         before do
           @html = @tester.link_to_remove_association('remove something', @form_obj, { wrapper_class: 'another-class' })
+          @button_html = @tester.button_to_remove_association('remove something', @form_obj, { wrapper_class: 'another-class' })
         end
 
         it_behaves_like "a correctly rendered remove link", { extra_attributes: { 'data-wrapper-class' => 'another-class' } }

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -4,6 +4,7 @@ shared_examples_for "a correctly rendered add link" do |options|
     before do
       default_options = {
           href: '#',
+          name: 'button',
           class: 'add_fields',
           template: "form<tag>",
           association: 'comment',
@@ -14,13 +15,13 @@ shared_examples_for "a correctly rendered add link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
-      @link = doc.at('a')
-    end
-    it 'has a correct href' do
-      expect(@link.attribute('href').value).to eq(@options[:href])
+      @link = doc.at('button')
     end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
+    end
+    it 'has a correct name' do
+      expect(@link.attribute('name').value).to eq(@options[:name])
     end
     it 'has a correct template' do
       expect(@link.attribute('data-association-insertion-template').value).to eq(@options[:template])
@@ -46,6 +47,7 @@ shared_examples_for "a correctly rendered remove link" do |options|
     before do
       default_options = {
           href: '#',
+          name: 'button',
           class: 'remove_fields dynamic',
           text: 'remove something',
           extra_attributes: {}
@@ -53,13 +55,13 @@ shared_examples_for "a correctly rendered remove link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
-      @link = doc.at('a')
-    end
-    it 'has a correct href' do
-      expect(@link.attribute('href').value).to eq(@options[:href])
+      @link = doc.at('button')
     end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
+    end
+    it 'has a correct name' do
+      expect(@link.attribute('name').value).to eq(@options[:name])
     end
     it 'has the correct text' do
       expect(@link.text).to eq(@options[:text])

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -4,6 +4,7 @@ shared_examples_for "a correctly rendered add link" do |options|
     before do
       default_options = {
           href: '#',
+          name: 'button',
           class: 'add_fields',
           template: "form<tag>",
           association: 'comment',
@@ -14,27 +15,35 @@ shared_examples_for "a correctly rendered add link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
+      button_doc = Nokogiri::HTML(@button_html)
       @link = doc.at('a')
+      @button = button_doc.at('button')
+    end
+    it 'has a correct class' do
+      expect(@link.attribute('class').value).to eq(@options[:class])
+      expect(@button.attribute('class').value).to eq(@options[:class])
     end
     it 'has a correct href' do
       expect(@link.attribute('href').value).to eq(@options[:href])
     end
-    it 'has a correct class' do
-      expect(@link.attribute('class').value).to eq(@options[:class])
-    end
     it 'has a correct template' do
       expect(@link.attribute('data-association-insertion-template').value).to eq(@options[:template])
+      expect(@button.attribute('data-association-insertion-template').value).to eq(@options[:template])
     end
     it 'has a correct associations' do
       expect(@link.attribute('data-association').value).to eq(@options[:association])
       expect(@link.attribute('data-associations').value).to eq(@options[:associations])
+      expect(@button.attribute('data-association').value).to eq(@options[:association])
+      expect(@button.attribute('data-associations').value).to eq(@options[:associations])
     end
     it 'has the correct text' do
       expect(@link.text).to eq(@options[:text])
+      expect(@button.text).to eq(@options[:text])
     end
     it 'sets extra attributes correctly' do
       @options[:extra_attributes].each do |key, value|
         expect(@link.attribute(key).value).to eq(value)
+        expect(@button.attribute(key).value).to eq(value)
       end
     end
 
@@ -55,11 +64,11 @@ shared_examples_for "a correctly rendered remove link" do |options|
       doc = Nokogiri::HTML(@html)
       @link = doc.at('a')
     end
-    it 'has a correct href' do
-      expect(@link.attribute('href').value).to eq(@options[:href])
-    end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
+    end
+    it 'has a correct href' do
+      expect(@link.attribute('href').value).to eq(@options[:href])
     end
     it 'has the correct text' do
       expect(@link.text).to eq(@options[:text])

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -4,7 +4,6 @@ shared_examples_for "a correctly rendered add link" do |options|
     before do
       default_options = {
           href: '#',
-          name: 'button',
           class: 'add_fields',
           template: "form<tag>",
           association: 'comment',
@@ -15,13 +14,13 @@ shared_examples_for "a correctly rendered add link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
-      @link = doc.at('button')
+      @link = doc.at('a')
+    end
+    it 'has a correct href' do
+      expect(@link.attribute('href').value).to eq(@options[:href])
     end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
-    end
-    it 'has a correct name' do
-      expect(@link.attribute('name').value).to eq(@options[:name])
     end
     it 'has a correct template' do
       expect(@link.attribute('data-association-insertion-template').value).to eq(@options[:template])
@@ -47,7 +46,6 @@ shared_examples_for "a correctly rendered remove link" do |options|
     before do
       default_options = {
           href: '#',
-          name: 'button',
           class: 'remove_fields dynamic',
           text: 'remove something',
           extra_attributes: {}
@@ -55,13 +53,13 @@ shared_examples_for "a correctly rendered remove link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
-      @link = doc.at('button')
+      @link = doc.at('a')
+    end
+    it 'has a correct href' do
+      expect(@link.attribute('href').value).to eq(@options[:href])
     end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
-    end
-    it 'has a correct name' do
-      expect(@link.attribute('name').value).to eq(@options[:name])
     end
     it 'has the correct text' do
       expect(@link.text).to eq(@options[:text])

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -26,6 +26,9 @@ shared_examples_for "a correctly rendered add link" do |options|
     it 'has a correct href' do
       expect(@link.attribute('href').value).to eq(@options[:href])
     end
+    it 'has a correct name' do
+      expect(@button.attribute('name').value).to eq(@options[:name])
+    end
     it 'has a correct template' do
       expect(@link.attribute('data-association-insertion-template').value).to eq(@options[:template])
       expect(@button.attribute('data-association-insertion-template').value).to eq(@options[:template])
@@ -55,6 +58,7 @@ shared_examples_for "a correctly rendered remove link" do |options|
     before do
       default_options = {
           href: '#',
+          name: 'button',
           class: 'remove_fields dynamic',
           text: 'remove something',
           extra_attributes: {}
@@ -62,20 +66,28 @@ shared_examples_for "a correctly rendered remove link" do |options|
       @options = default_options.merge options
 
       doc = Nokogiri::HTML(@html)
+      button_doc = Nokogiri::HTML(@button_html)
       @link = doc.at('a')
+      @button = button_doc.at('button')
     end
     it 'has a correct class' do
       expect(@link.attribute('class').value).to eq(@options[:class])
+      expect(@button.attribute('class').value).to eq(@options[:class])
     end
     it 'has a correct href' do
       expect(@link.attribute('href').value).to eq(@options[:href])
     end
+    it 'has a correct name' do
+      expect(@button.attribute('name').value).to eq(@options[:name])
+    end
     it 'has the correct text' do
       expect(@link.text).to eq(@options[:text])
+      expect(@button.text).to eq(@options[:text])
     end
     it 'sets extra attributes correctly' do
       @options[:extra_attributes].each do |key, value|
         expect(@link.attribute(key).value).to eq(value)
+        expect(@button.attribute(key).value).to eq(value)
       end
     end
   end


### PR DESCRIPTION
Changed the text links in link_to_remove_association and link_to_add_association to buttons. I also updated the specs to suit this.