### PR TITLE
Don't directly load AV::Base in the initializer, but use AS lazy load hook

### DIFF
--- a/lib/cocoon.rb
+++ b/lib/cocoon.rb
@@ -11,7 +11,9 @@ module Cocoon
 
     # configure our plugin on boot
     initializer "cocoon.initialize" do |app|
-      ActionView::Base.send :include, Cocoon::ViewHelpers
+      ActiveSupport.on_load :action_view do
+        ActionView::Base.send :include, Cocoon::ViewHelpers
+      end
     end
 
   end


### PR DESCRIPTION
Currently released cocoon immediately loads ActionView Base class and fires all action_view related hooks in the initializer proccess.

This patch fixed this situation by properly configuring the ActiveSupport on_load hook as documented here: http://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html