### PR TITLE
Make _destroy persist through validation with Mongoid

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -37,7 +37,7 @@ module Cocoon
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
 
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
+        hidden_field_tag("#{f.object_name}[_destroy]", f.object.marked_for_destruction?) + link_to(name, '#', html_options)
       end
     end
 


### PR DESCRIPTION
Mongoid does not persist the _destroy param through validation issues, as seen here: https://github.com/mongodb/mongoid/blob/71c29a80599087008ecfbd057d3d049c2153c7ce/lib/mongoid/railties/document.rb

Switching this to `marked_for_destruction?`, which is used above in the same method, does work properly though.