### PR TITLE
Add package.json with private set to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cocoon",
+  "version": "1.2.10",
+  "private": true,
+  "description": "Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms",
+  "main": "app/assets/javascripts/cocoon.js",
+  "files": [
+    "app/assets/javascripts"
+  ],
+  "repository": "https://github.com/nathanvda/cocoon",
+  "author": "Nathan Van der Auwera <nathan@dixis.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nathanvda/cocoon/issues"
+  },
+  "homepage": "https://github.com/nathanvda/cocoon#readme"
+}


### PR DESCRIPTION
At the company I work for we've been using Cocoon for more than 2 years now. Thanks @nathanvda and everyone that contributed! 👏 

We recently migrated to Rails 5.1 and stopped using the Asset Pipeline to compile our JavaScript (we're using the Rails Webpacker gem). This means we can't require JavaScript like this anymore:

```js
//= require cocoon
```

I've read issues #363 and #452 and understand if the author is not interested in maintaining another package in a different registry (NPM). What I propose in this PR is a compromise solution.

This PR adds a `package.json` file with the property [`private`](https://docs.npmjs.com/files/package.json#private) set to `true`. This lets users that visit this repository know that the JavaScript is not officially published in the NPM registry, but at the same time they can install Cocoon directly from GitHub:

```bash
# Using the NPM client
npm install github:nathanvda/cocoon --save

# Using the Yarn client
yarn add github:nathanvda/cocoon
```

They can then import the code like this:

```es
import "cocoon";
```

The `package.json` includes a `version` because it is a required property, but even if this property is not updated, users can always install a specific commit, similarly to what we do in a `Gemfile`:

```bash
npm install github:nathanvda/cocoon#c24ba53
```

---

_Side note:_ If in the future @nathanvda finds it valuable to publish the package in the NPM registry, he would simply have to remove the `private` property, update the `version`, and run `npm publish`.

Both names "cocoon" and "cocoon-rails" are taken, but the author can use a [scoped name](https://docs.npmjs.com/misc/scope). Assuming the NPM username `nathanvda`, the name property could be `@nathanvda/cocoon`.