### PR TITLE
Add note on how to silence after_add trigger with force_non_association_create

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -318,8 +318,9 @@ a new nested object.
 This used to have a side-effect: for each call of `link_to_add_association` a new element was added to the association.
 This is no longer the case.
 
-For backward compatibility we keep this option for now. Or if for some specific reason you would
-really need an object to be _not_ created on the association.
+For backward compatibility we keep this option for now. Or if for some specific reason you would really need an object
+to be _not_ created on the association, for example if you did not want `after_add` callback to be triggered on
+the association.
 
 Example use:
 


### PR DESCRIPTION
Took me a while to figure out why records were being `touched` whenever someone loaded the edit screen.

Turns out it was because `link_to_add_association` was firing `after_add` callback on my `has_many` association. 

This was fixed by passing `force_non_association_create: true` 

Hopefully adding an example use case for this option means it won't be removed and will help anyone out in the future.