### PR TITLE
 #render_association should add id to field name attributes in case of non-association inputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,12 @@ group :development, :test do
   gem "rails", "~> 4.2"
   gem "sqlite3", '1.3.13'
   gem "json_pure"
-  gem "jeweler", "~> 2.3"
+  # Requires ruby version >= 2.2.2.
+  # https://github.com/technicalpickles/jeweler/commit/6e1fc653b79a85a87b20274fa3e5d28dca8c9e15#diff-085ee3a98b1501b5e8fe6c41b7f4a348R193
+  gem "jeweler", "< 2.3"
+  # Requires ruby version >= 2.2.2.
+  # https://github.com/ruby/rdoc/commit/51b03c357457183e94a6b26d71630f183afbc6b0#diff-a3e11f586091452d2935675e4439ad53R49
+  gem "rdoc", "< 6"
   gem "rspec-rails", "~> 3.0.0"
   gem "rspec",       "~> 3.0.0"
   gem "actionpack",  ">=4.0.0"

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -47,7 +47,8 @@ module Cocoon
       locals =  render_options.delete(:locals) || {}
       ancestors = f.class.ancestors.map{|c| c.to_s}
       method_name = ancestors.include?('SimpleForm::FormBuilder') ? :simple_fields_for : (ancestors.include?('Formtastic::FormBuilder') ? :semantic_fields_for : :fields_for)
-      f.send(method_name, association, new_object, {:child_index => "new_#{association}"}.merge(render_options)) do |builder|
+      index = "new_#{association}"
+      f.send(method_name, association, new_object, {:child_index => index, :index => index}.merge(render_options)) do |builder|
         partial_options = {form_name.to_sym => builder, :dynamic => true}.merge(locals)
         render(partial, partial_options)
       end


### PR DESCRIPTION
The "new_#{association}" input name part is missing for inputs without associations.
 I cannot find any docs on `index` and `child_index` `fields_for` options. The closest thing I have found is [this comment](https://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for#1435-Using-fields-for-with-collection-no-association-).
The tests don't look like they test any interaction with rails, so can anyone confirm this does not break anything?