### PR TITLE
Use .detach() instead of .remove() for removing dynamic assocs

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -114,7 +114,7 @@
 
       setTimeout(function() {
         if ($this.hasClass('dynamic')) {
-            node_to_delete.remove();
+            node_to_delete.detach();
         } else {
             $this.prev("input[type=hidden]").val("1");
             node_to_delete.hide();


### PR DESCRIPTION
From [the jQuery docs for `.detach()`](https://api.jquery.com/detach/#entry-longdesc):

> The `.detach()` method is the same as [`.remove()`](https://api.jquery.com/remove/), except that `.detach()` keeps all jQuery data associated with the removed elements.

Submitting this because we needed to do some extra processing on some data which was set via jQuery's [`.data()`](https://api.jquery.com/data/).

See also: [this Stack Overflow question](https://stackoverflow.com/q/25121168/2384183)