### PR TITLE
don't assume a reflect_on_association method

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -108,7 +108,7 @@ module Cocoon
     # will create new Comment with author "Admin"
 
     def create_object(f, association, force_non_association_create=false)
-      assoc = f.object.class.reflect_on_association(association)
+      assoc = f.object.class.respond_to?(:reflect_on_association) && f.object.class.reflect_on_association(association)
 
       assoc ? create_object_on_association(f, association, assoc, force_non_association_create) : create_object_on_non_association(f, association)
     end


### PR DESCRIPTION
I'm experimenting with using cocoon in a context where some of the models involved are ActiveModels rather than ActiveRecord::Base.  For my work with [this gem](https://github.com/jrochkind/json_attribute).

It actually works out pretty well, most parts of cocoon don't assume that the collections involved actually have AR reflection info, for instance.   Perhaps some work has gone in this direction before!

There are just a couple places where cocoon is assuming methods exist where I'd rather it didn't. 

This is one of them, which seems pretty straightforward to do something about -- it was accepting a `nil` return value from `reflect_on_association` anyway (and doing the right thing for my use case in that situation), so just have it not try to call the method if it doesn't exist, and just go with the nil value. Seems quite clean and neat. 

What do you think?