### PR TITLE
change method of hiding nodes marked for deletion

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -101,6 +101,7 @@
   $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
     var $this = $(this),
         wrapper_class = $this.data('wrapper-class') || 'nested-fields',
+        hide_style = $this.data('hide-style') || 'display: none',
         node_to_delete = $this.closest('.' + wrapper_class),
         trigger_node = node_to_delete.parent();
 
@@ -117,7 +118,7 @@
             node_to_delete.detach();
         } else {
             $this.prev("input[type=hidden]").val("1");
-            node_to_delete.attr('style', 'display: none !important');
+            node_to_delete.attr('style', hide_style);
         }
         trigger_node.trigger('cocoon:after-remove', [node_to_delete]);
       }, timeout);
@@ -128,9 +129,10 @@
   $(document).on("ready page:load turbolinks:load", function() {
     $('.remove_fields.existing.destroyed').each(function(i, obj) {
       var $this = $(this),
-          wrapper_class = $this.data('wrapper-class') || 'nested-fields';
+          wrapper_class = $this.data('wrapper-class') || 'nested-fields',
+          hide_style = $this.data('hide-style') || 'display: none';
 
-      $this.closest('.' + wrapper_class).attr('style', 'display: none !important');
+      $this.closest('.' + wrapper_class).attr('style', hide_style);
     });
   });
 

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -117,7 +117,7 @@
             node_to_delete.detach();
         } else {
             $this.prev("input[type=hidden]").val("1");
-            node_to_delete.hide();
+            node_to_delete.attr('style', 'display: none !important');
         }
         trigger_node.trigger('cocoon:after-remove', [node_to_delete]);
       }, timeout);
@@ -130,7 +130,7 @@
       var $this = $(this),
           wrapper_class = $this.data('wrapper-class') || 'nested-fields';
 
-      $this.closest('.' + wrapper_class).hide();
+      $this.closest('.' + wrapper_class).attr('style', 'display: none !important');
     });
   });
 

--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -34,8 +34,10 @@ module Cocoon
         classes << 'destroyed' if f.object.marked_for_destruction?
         html_options[:class] = [html_options[:class], classes.join(' ')].compact.join(' ')
 
+        hide_style = html_options.delete(:hide_style)
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
+        html_options[:'data-hide-style'] = hide_style if hide_style.present?
 
         hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
       end

--- a/spec/cocoon_spec.rb
+++ b/spec/cocoon_spec.rb
@@ -378,6 +378,24 @@ describe Cocoon do
         it_behaves_like "a correctly rendered remove link", { extra_attributes: { 'data-wrapper-class' => 'another-class' } }
       end
     end
+
+    context 'when change display hide method' do
+      context 'should use the default display: none style' do
+        before do
+          @html = @tester.link_to_remove_association('remove something', @form_obj)
+        end
+
+        it_behaves_like "a correctly rendered remove link", { }
+      end
+
+      context 'should use the given hide method' do
+        before do
+          @html = @tester.link_to_remove_association('remove something', @form_obj, { hide_style: 'opacity: 0' })
+        end
+
+        it_behaves_like "a correctly rendered remove link", { extra_attributes: { 'data-hide-style' => 'opacity: 0' } }
+      end
+    end
   end
 
   context "create_object" do


### PR DESCRIPTION
For `link_to_remove_association` method when `wrapper_class` attribute set to any bootstrap 4+ display class jQuery hide() function does not work.

That happens because all bootstrap 4 classes has !important flag for display properties. You can check source bootstrap 4 code [here](https://getbootstrap.com/docs/4.1/utilities/display/#how-it-works)
Against `display: flex !important` property `display: none;` becomes useless.