### PR TITLE
prevents propagation to parent elements

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -105,6 +105,7 @@
         trigger_node = node_to_delete.parent();
 
     e.preventDefault();
+    e.stopPropagation();
 
     var before_remove = jQuery.Event('cocoon:before-remove');
     trigger_node.trigger(before_remove, [node_to_delete]);


### PR DESCRIPTION
So the problem I have is that I display a nested form in a dropdown (eg: list of items in a shopping cart). When I click on the ```.remove_fields.existing``` element the dropdown is closed because the click event propagates through the parent elements which is not the expected behavior and I also think that is good practice to prevent side-effects that may cause problems to the library users.