### PR TITLE
Segmenting responsibilities in #add_field jquery

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -2,6 +2,7 @@
 
   var cocoon_element_counter = 0;
 
+  // unique id that will not conflict with rails
   var create_new_id = function() {
     return (new Date().getTime() + cocoon_element_counter++);
   }
@@ -10,19 +11,118 @@
     return '[' + id + ']$1';
   }
 
-  var newcontent_underscord = function(id) {
+  var newcontent_underscored = function(id) {
     return '_' + id + '_$1';
   }
+  
+  // Format association to add text
+  var regexp_bracer = function(target_association) {
+    return new RegExp('\\[new_' + target_association + '\\](.*?\\s)', 'g')
+  }
+  
+  // Format association to add text
+  var regexp_underscorer = function(target_association) {
+    return new RegExp('_new_' + target_association + '_(\\w*)', 'g')
+  }
 
-  var getInsertionNodeElem = function(insertionNode, insertionTraversal, $this){
+  // Return array of regex wrappers assocation ids & loop through all the id(s) 
+  var associationIdBuilder = function(count, assoc, assocs, content) {
+    
+    var regexp_braced       = regexp_bracer(assoc),
+        regexp_underscored  = regexp_underscorer(assoc)
+        new_id              = create_new_id(),
+        new_contents        = [];
+    
+    var new_content = content.replace(regexp_braced, newcontent_braced(new_id));
+    
+    // Toggle over to multiple associations if found
+    if (new_content == content) {
+      regexp_braced       = regexp_bracer(assocs);
+      regexp_underscored  = regexp_underscorer(assocs);
+      new_content   = content.replace(regexp_braced, newcontent_braced(new_id));
+    }
+    
+    new_content = new_content.replace(regexp_underscored, newcontent_underscored(new_id));
+    new_contents = [new_content]
+    
+    count = (isNaN(count) ? 1 : Math.max(count, 1));
+    count -= 1;
 
+    // If count over 0, we know to keep adding on rest of names with new ids
+    while (count) {
+      new_id      = create_new_id();
+      new_content = content.replace(regexp_braced, newcontent_braced(new_id));
+      new_content = new_content.replace(regexp_underscored, newcontent_underscored(new_id));
+      new_contents.push(new_content);
+
+      count -= 1;
+    }
+    return new_contents
+  }
+
+  $(document).on('click', '.add_fields', function(e) {
+    e.preventDefault();
+
+    // Needed for both responsibilities
+    var $this                 = $(this),
+        new_contents          = [];
+        
+    // Association name builder vars
+    var assoc                 = $this.data('association'),
+        assocs                = $this.data('associations'),
+        content               = $this.data('association-insertion-template'),
+        count                 = parseInt($this.data('count'), 10);
+        
+    // association data insertion vars
+    var insert_method   = $this.data('association-insertion-method'),
+        insert_position = $this.data('association-insertion-position'), 
+        insertionMethod       = insert_method || insert_position || 'before',
+        // insertionNode         = $this.data('association-insertion-node'),
+        // insertionTraversal    = $this.data('association-insertion-traversal');
+
+    // Single or multiple assocations in proper format with non-rails unique id 
+    new_contents = associationIdBuilder(count, assoc, assocs, content)
+
+    var insertionNodeElem = getInsertionNodeElem($this)
+
+    if( !insertionNodeElem || (insertionNodeElem.length == 0) ){
+      console.warn("Couldn't find the element to insert the template. Make sure\
+        your `data-association-insertion-*` on `link_to_add_association` is\
+        correct.")
+    }
+
+    $.each(new_contents, function(i, node) {
+      var contentNode = $(node);
+
+      var before_insert = jQuery.Event('cocoon:before-insert');
+      insertionNodeElem.trigger(before_insert, [contentNode]);
+
+      if (!before_insert.isDefaultPrevented()) {
+        // Allow any of the jquery dom manipulation methods 
+        // ... (after, before, append, prepend, etc) to be called on the node.  
+        // Allows the insertion node to be the parent of the inserted code and 
+        // ... doesn't force it to be a sibling like after/before does. 
+        // Default: 'before'
+        var addedContent = insertionNodeElem[insertionMethod](contentNode);
+
+        insertionNodeElem.trigger('cocoon:after-insert', [contentNode]);
+      }
+    });
+  });
+
+  // Jquery parent & positioning information
+  var getInsertionNodeElem = function($this){
+    var insertionNode         = $this.data('association-insertion-node'),
+        insertionTraversal    = $this.data('association-insertion-traversal');
+        
     if (!insertionNode){
       return $this.parent();
     }
 
     if (typeof insertionNode == 'function'){
       if(insertionTraversal){
-        console.warn('association-insertion-traversal is ignored, because association-insertion-node is given as a function.')
+        console.warn('association-insertion-traversal is ignored, because\
+          association-insertion-node is given as a function.')
       }
       return insertionNode($this);
     }
@@ -34,69 +134,7 @@
         return insertionNode == "this" ? $this : $(insertionNode);
       }
     }
-
   }
-
-  $(document).on('click', '.add_fields', function(e) {
-    e.preventDefault();
-    var $this                 = $(this),
-        assoc                 = $this.data('association'),
-        assocs                = $this.data('associations'),
-        content               = $this.data('association-insertion-template'),
-        insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before',
-        insertionNode         = $this.data('association-insertion-node'),
-        insertionTraversal    = $this.data('association-insertion-traversal'),
-        count                 = parseInt($this.data('count'), 10),
-        regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
-        regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
-        new_id                = create_new_id(),
-        new_content           = content.replace(regexp_braced, newcontent_braced(new_id)),
-        new_contents          = [];
-
-
-    if (new_content == content) {
-      regexp_braced     = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
-      regexp_underscord = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
-      new_content       = content.replace(regexp_braced, newcontent_braced(new_id));
-    }
-
-    new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
-    new_contents = [new_content];
-
-    count = (isNaN(count) ? 1 : Math.max(count, 1));
-    count -= 1;
-
-    while (count) {
-      new_id      = create_new_id();
-      new_content = content.replace(regexp_braced, newcontent_braced(new_id));
-      new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
-      new_contents.push(new_content);
-
-      count -= 1;
-    }
-
-    var insertionNodeElem = getInsertionNodeElem(insertionNode, insertionTraversal, $this)
-
-    if( !insertionNodeElem || (insertionNodeElem.length == 0) ){
-      console.warn("Couldn't find the element to insert the template. Make sure your `data-association-insertion-*` on `link_to_add_association` is correct.")
-    }
-
-    $.each(new_contents, function(i, node) {
-      var contentNode = $(node);
-
-      var before_insert = jQuery.Event('cocoon:before-insert');
-      insertionNodeElem.trigger(before_insert, [contentNode]);
-
-      if (!before_insert.isDefaultPrevented()) {
-        // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
-        // to be called on the node.  allows the insertion node to be the parent of the inserted
-        // code and doesn't force it to be a sibling like after/before does. default: 'before'
-        var addedContent = insertionNodeElem[insertionMethod](contentNode);
-
-        insertionNodeElem.trigger('cocoon:after-insert', [contentNode]);
-      }
-    });
-  });
 
   $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
     var $this = $(this),
@@ -123,7 +161,6 @@
       }, timeout);
     }
   });
-
 
   $(document).on("ready page:load turbolinks:load", function() {
     $('.remove_fields.existing.destroyed').each(function(i, obj) {


### PR DESCRIPTION
- Regex makers moved to their own functions

- Isolated #add_field's responsibilities wrapping assoc id to another function

- Cut extraneous passing of parameters in getInsertionNodeElem as we already pass $this