### PR TITLE
Add originalEvent extra param to insert and remove events

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -368,13 +368,14 @@ On insertion or removal the following events are triggered:
 To listen to the events in your JavaScript:
 
 ```javascript
-  $('#container').on('cocoon:before-insert', function(e, insertedItem) {
+  $('#container').on('cocoon:before-insert', function(e, insertedItem, originalEvent) {
     // ... do something
   });
 ```
 
 ...where `e` is the event and the second parameter is the inserted or removed item. This allows you to change markup, or
 add effects/animations (see example below).
+`originalEvent` is also passed and references the event that triggered an insertion or removal (e.g. the `click` event on the link to add an association)
 
 
 If in your view you have the following snippet to select an `owner`:

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -51,7 +51,8 @@
         regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
         new_id                = create_new_id(),
         new_content           = content.replace(regexp_braced, newcontent_braced(new_id)),
-        new_contents          = [];
+        new_contents          = [],
+        originalEvent         = e;
 
 
     if (new_content == content) {
@@ -85,7 +86,7 @@
       var contentNode = $(node);
 
       var before_insert = jQuery.Event('cocoon:before-insert');
-      insertionNodeElem.trigger(before_insert, [contentNode]);
+      insertionNodeElem.trigger(before_insert, [contentNode, originalEvent]);
 
       if (!before_insert.isDefaultPrevented()) {
         // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
@@ -93,7 +94,8 @@
         // code and doesn't force it to be a sibling like after/before does. default: 'before'
         var addedContent = insertionNodeElem[insertionMethod](contentNode);
 
-        insertionNodeElem.trigger('cocoon:after-insert', [contentNode]);
+        insertionNodeElem.trigger('cocoon:after-insert', [contentNode,
+          originalEvent]);
       }
     });
   });
@@ -102,13 +104,14 @@
     var $this = $(this),
         wrapper_class = $this.data('wrapper-class') || 'nested-fields',
         node_to_delete = $this.closest('.' + wrapper_class),
-        trigger_node = node_to_delete.parent();
+        trigger_node = node_to_delete.parent(),
+        originalEvent = e;
 
     e.preventDefault();
     e.stopPropagation();
 
     var before_remove = jQuery.Event('cocoon:before-remove');
-    trigger_node.trigger(before_remove, [node_to_delete]);
+    trigger_node.trigger(before_remove, [node_to_delete, originalEvent]);
 
     if (!before_remove.isDefaultPrevented()) {
       var timeout = trigger_node.data('remove-timeout') || 0;
@@ -120,7 +123,8 @@
             $this.prev("input[type=hidden]").val("1");
             node_to_delete.hide();
         }
-        trigger_node.trigger('cocoon:after-remove', [node_to_delete]);
+        trigger_node.trigger('cocoon:after-remove', [node_to_delete,
+          originalEvent]);
       }, timeout);
     }
   });


### PR DESCRIPTION
There are some times in which it would be useful having access to the original event that triggered an item insertion or removal. For example:

```javascript
let ev = $.Event('click')
ev.myData = 'something'
$('#items .links .add_fields').trigger(ev)

$(document).on('cocoon:after-insert', '#items', function(ev, inserted, originalEvent) {
  console.log(originalEvent.myData) // 'something'
})
```

This PR enables this use case.