### PR TITLE
Use form builder to add hidden `_destroy` field

### DIFF
--- a/lib/cocoon/view_helpers.rb
+++ b/lib/cocoon/view_helpers.rb
@@ -37,7 +37,7 @@ module Cocoon
         wrapper_class = html_options.delete(:wrapper_class)
         html_options[:'data-wrapper-class'] = wrapper_class if wrapper_class.present?
 
-        hidden_field_tag("#{f.object_name}[_destroy]", f.object._destroy) + link_to(name, '#', html_options)
+        f.hidden_field(:_destroy, value: f.object._destroy) + link_to(name, '#', html_options)
       end
     end
 


### PR DESCRIPTION
I've changed the hidden field in `link_to_remove_association` to use the form builder supplied by the user, instead of using `hidden_form_tag`.

This lets us inherit settings from the form builder such as `namespace`, allowing multiple cocoon-enabled forms on the same page without getting a nonunique id warning from the browser's DOM. Using `hidden_form_tag` like cocoon did previously ignores that, and other settings from the form builder.