### PR TITLE
Wrap library with UMD and add npm release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,8 @@ require 'rdoc/task'
 require 'rspec/core'
 require 'rspec/core/rake_task'
 
+require_relative './lib/tasks/release'
+
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -1,146 +1,155 @@
-(function($) {
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery')) :
+  typeof define === 'function' && define.amd ? define(['jquery'], factory) :
+  (global = global || self, factory(global.jQuery));
+}(this, (function (jQuery) {
+  'use strict';
 
-  var cocoon_element_counter = 0;
+  jQuery = jQuery && Object.prototype.hasOwnProperty.call(jQuery, 'default') ? jQuery['default'] : jQuery;
 
-  var create_new_id = function() {
-    return (new Date().getTime() + cocoon_element_counter++);
-  }
+  (function($) {
 
-  var newcontent_braced = function(id) {
-    return '[' + id + ']$1';
-  }
+    var cocoon_element_counter = 0;
 
-  var newcontent_underscord = function(id) {
-    return '_' + id + '_$1';
-  }
+    var create_new_id = function() {
+      return (new Date().getTime() + cocoon_element_counter++);
+    };
 
-  var getInsertionNodeElem = function(insertionNode, insertionTraversal, $this){
+    var newcontent_braced = function(id) {
+      return '[' + id + ']$1';
+    };
 
-    if (!insertionNode){
-      return $this.parent();
-    }
+    var newcontent_underscord = function(id) {
+      return '_' + id + '_$1';
+    };
 
-    if (typeof insertionNode == 'function'){
-      if(insertionTraversal){
-        console.warn('association-insertion-traversal is ignored, because association-insertion-node is given as a function.')
+    var getInsertionNodeElem = function(insertionNode, insertionTraversal, $this){
+
+      if (!insertionNode){
+        return $this.parent();
       }
-      return insertionNode($this);
-    }
 
-    if(typeof insertionNode == 'string'){
-      if (insertionTraversal){
-        return $this[insertionTraversal](insertionNode);
-      }else{
-        return insertionNode == "this" ? $this : $(insertionNode);
-      }
-    }
-
-  }
-
-  $(document).on('click', '.add_fields', function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    
-    var $this                 = $(this),
-        assoc                 = $this.data('association'),
-        assocs                = $this.data('associations'),
-        content               = $this.data('association-insertion-template'),
-        insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before',
-        insertionNode         = $this.data('association-insertion-node'),
-        insertionTraversal    = $this.data('association-insertion-traversal'),
-        count                 = parseInt($this.data('count'), 10),
-        regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
-        regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
-        new_id                = create_new_id(),
-        new_content           = content.replace(regexp_braced, newcontent_braced(new_id)),
-        new_contents          = [],
-        originalEvent         = e;
-
-
-    if (new_content == content) {
-      regexp_braced     = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
-      regexp_underscord = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
-      new_content       = content.replace(regexp_braced, newcontent_braced(new_id));
-    }
-
-    new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
-    new_contents = [new_content];
-
-    count = (isNaN(count) ? 1 : Math.max(count, 1));
-    count -= 1;
-
-    while (count) {
-      new_id      = create_new_id();
-      new_content = content.replace(regexp_braced, newcontent_braced(new_id));
-      new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
-      new_contents.push(new_content);
-
-      count -= 1;
-    }
-
-    var insertionNodeElem = getInsertionNodeElem(insertionNode, insertionTraversal, $this)
-
-    if( !insertionNodeElem || (insertionNodeElem.length == 0) ){
-      console.warn("Couldn't find the element to insert the template. Make sure your `data-association-insertion-*` on `link_to_add_association` is correct.")
-    }
-
-    $.each(new_contents, function(i, node) {
-      var contentNode = $(node);
-
-      var before_insert = jQuery.Event('cocoon:before-insert');
-      insertionNodeElem.trigger(before_insert, [contentNode, originalEvent]);
-
-      if (!before_insert.isDefaultPrevented()) {
-        // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
-        // to be called on the node.  allows the insertion node to be the parent of the inserted
-        // code and doesn't force it to be a sibling like after/before does. default: 'before'
-        var addedContent = insertionNodeElem[insertionMethod](contentNode);
-
-        insertionNodeElem.trigger('cocoon:after-insert', [contentNode,
-          originalEvent]);
-      }
-    });
-  });
-
-  $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
-    var $this = $(this),
-        wrapper_class = $this.data('wrapper-class') || 'nested-fields',
-        node_to_delete = $this.closest('.' + wrapper_class),
-        trigger_node = node_to_delete.parent(),
-        originalEvent = e;
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    var before_remove = jQuery.Event('cocoon:before-remove');
-    trigger_node.trigger(before_remove, [node_to_delete, originalEvent]);
-
-    if (!before_remove.isDefaultPrevented()) {
-      var timeout = trigger_node.data('remove-timeout') || 0;
-
-      setTimeout(function() {
-        if ($this.hasClass('dynamic')) {
-            node_to_delete.detach();
-        } else {
-            $this.prev("input[type=hidden]").val("1");
-            node_to_delete.hide();
+      if (typeof insertionNode == 'function'){
+        if(insertionTraversal){
+          console.warn('association-insertion-traversal is ignored, because association-insertion-node is given as a function.');
         }
-        trigger_node.trigger('cocoon:after-remove', [node_to_delete,
-          originalEvent]);
-      }, timeout);
-    }
-  });
+        return insertionNode($this);
+      }
+
+      if(typeof insertionNode == 'string'){
+        if (insertionTraversal){
+          return $this[insertionTraversal](insertionNode);
+        }else {
+          return insertionNode == "this" ? $this : $(insertionNode);
+        }
+      }
+
+    };
+
+    $(document).on('click', '.add_fields', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var $this                 = $(this),
+          assoc                 = $this.data('association'),
+          assocs                = $this.data('associations'),
+          content               = $this.data('association-insertion-template'),
+          insertionMethod       = $this.data('association-insertion-method') || $this.data('association-insertion-position') || 'before',
+          insertionNode         = $this.data('association-insertion-node'),
+          insertionTraversal    = $this.data('association-insertion-traversal'),
+          count                 = parseInt($this.data('count'), 10),
+          regexp_braced         = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g'),
+          regexp_underscord     = new RegExp('_new_' + assoc + '_(\\w*)', 'g'),
+          new_id                = create_new_id(),
+          new_content           = content.replace(regexp_braced, newcontent_braced(new_id)),
+          new_contents          = [],
+          originalEvent         = e;
 
 
-  $(document).on("ready page:load turbolinks:load", function() {
-    $('.remove_fields.existing.destroyed').each(function(i, obj) {
-      var $this = $(this),
-          wrapper_class = $this.data('wrapper-class') || 'nested-fields';
+      if (new_content == content) {
+        regexp_braced     = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
+        regexp_underscord = new RegExp('_new_' + assocs + '_(\\w*)', 'g');
+        new_content       = content.replace(regexp_braced, newcontent_braced(new_id));
+      }
 
-      $this.closest('.' + wrapper_class).hide();
+      new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
+      new_contents = [new_content];
+
+      count = (isNaN(count) ? 1 : Math.max(count, 1));
+      count -= 1;
+
+      while (count) {
+        new_id      = create_new_id();
+        new_content = content.replace(regexp_braced, newcontent_braced(new_id));
+        new_content = new_content.replace(regexp_underscord, newcontent_underscord(new_id));
+        new_contents.push(new_content);
+
+        count -= 1;
+      }
+
+      var insertionNodeElem = getInsertionNodeElem(insertionNode, insertionTraversal, $this);
+
+      if( !insertionNodeElem || (insertionNodeElem.length == 0) ){
+        console.warn("Couldn't find the element to insert the template. Make sure your `data-association-insertion-*` on `link_to_add_association` is correct.");
+      }
+
+      $.each(new_contents, function(i, node) {
+        var contentNode = $(node);
+
+        var before_insert = jQuery.Event('cocoon:before-insert');
+        insertionNodeElem.trigger(before_insert, [contentNode, originalEvent]);
+
+        if (!before_insert.isDefaultPrevented()) {
+          // allow any of the jquery dom manipulation methods (after, before, append, prepend, etc)
+          // to be called on the node.  allows the insertion node to be the parent of the inserted
+          // code and doesn't force it to be a sibling like after/before does. default: 'before'
+          var addedContent = insertionNodeElem[insertionMethod](contentNode);
+
+          insertionNodeElem.trigger('cocoon:after-insert', [contentNode,
+            originalEvent]);
+        }
+      });
     });
-  });
 
-})(jQuery);
+    $(document).on('click', '.remove_fields.dynamic, .remove_fields.existing', function(e) {
+      var $this = $(this),
+          wrapper_class = $this.data('wrapper-class') || 'nested-fields',
+          node_to_delete = $this.closest('.' + wrapper_class),
+          trigger_node = node_to_delete.parent(),
+          originalEvent = e;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      var before_remove = jQuery.Event('cocoon:before-remove');
+      trigger_node.trigger(before_remove, [node_to_delete, originalEvent]);
+
+      if (!before_remove.isDefaultPrevented()) {
+        var timeout = trigger_node.data('remove-timeout') || 0;
+
+        setTimeout(function() {
+          if ($this.hasClass('dynamic')) {
+              node_to_delete.detach();
+          } else {
+              $this.prev("input[type=hidden]").val("1");
+              node_to_delete.hide();
+          }
+          trigger_node.trigger('cocoon:after-remove', [node_to_delete,
+            originalEvent]);
+        }, timeout);
+      }
+    });
 
 
+    $(document).on("ready page:load turbolinks:load", function() {
+      $('.remove_fields.existing.destroyed').each(function(i, obj) {
+        var $this = $(this),
+            wrapper_class = $this.data('wrapper-class') || 'nested-fields';
+
+        $this.closest('.' + wrapper_class).hide();
+      });
+    });
+
+  })(jQuery);
+
+})));

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -13,4 +13,12 @@ namespace :release do
   task :update_npm_version do
     system "npm version #{npm_version} --no-git-tag-version"
   end
+
+  task :publish_npm_package do
+    npm_tag = /[a-z]/.match?(version) ? "pre" : "latest"
+    system "npm publish --tag #{npm_tag}"
+  end
+
+  desc "Build and release cocoon.js as NPM package"
+  task npm: [:update_npm_version, :publish_npm_package]
 end

--- a/lib/tasks/release.rb
+++ b/lib/tasks/release.rb
@@ -1,0 +1,16 @@
+namespace :release do
+  root    = File.expand_path("../..", __dir__)
+  version = File.read("VERSION").strip
+
+  # "5.0.1"     --> "5.0.1"
+  # "5.0.1.1"   --> "5.0.1-1" *
+  # "5.0.0.rc1" --> "5.0.0-rc1"
+  #
+  # * This makes it a prerelease. That's bad, but we haven't come up with
+  # a better solution at the moment.
+  npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
+
+  task :update_npm_version do
+    system "npm version #{npm_version} --no-git-tag-version"
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cocoon",
+  "version": "1.2.10",
+  "private": true,
+  "description": "Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms",
+  "main": "app/assets/javascripts/cocoon.js",
+  "files": [
+    "app/assets/javascripts"
+  ],
+  "repository": "https://github.com/nathanvda/cocoon",
+  "author": "Nathan Van der Auwera <nathan@dixis.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nathanvda/cocoon/issues"
+  },
+  "homepage": "https://github.com/nathanvda/cocoon#readme"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cocoon",
   "version": "1.2.14",
   "private": true,
-  "description": "Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms",
+  "description": "Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms. This package is designed solely to be used in conjunction with the cocoon gem for Rails application.",
   "main": "app/assets/javascripts/cocoon.js",
   "files": [
     "app/assets/javascripts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cocoon",
-  "version": "1.2.10",
+  "version": "1.2.14",
   "private": true,
   "description": "Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms",
   "main": "app/assets/javascripts/cocoon.js",


### PR DESCRIPTION
Builds on #454 which adds a package.json field.

This PR adds the following features:

1. A release task `rake release:npm` that can be run to publish this library to NPM. The task will ensure that the NPM release version matches the info in `VERSION`.
1. Wraps `cocoon.js` in Universal Module Definition (UMD). This is an immediately-invoked function expression (IIFE) that is compatible with browser and Node.js environments, i.e., applications that use Sprockets and applications that use Webpacker to bundle JavaScript.

I've also added to the description in `package.json` to clarify for end-users that this package is designed solely for use with the cocoon gem.

A note about the UMD expression: I used `rollup` locally to generate this wrapper, which is the only modification to the `cocoon.js` file. It might make more sense, typically, to add this wrapper as a build step and use a tool (like rollup or any module bundler) to develop locally against the "unwrapped" code, but I didn't want to dictate that change to the owner.

Generally, I believe this is these changes represent the path forward for "asset gems" to best accommodate both Sprockets and module-bundlers, like `webpack` for Rails applications. I hope you find this useful.
