### PR TITLE
Fix build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ rvm:
   - rbx-2
 
 before_install:
-    - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-    - gem install bundler -v '< 2'
+  - find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete
+  - gem install bundler -v '< 2'
       
 gemfile:
   - gemfiles/Gemfile.rails-3.2.13

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ require 'rdoc/task'
 require 'rspec/core'
 require 'rspec/core/rake_task'
 require 'erb'
-require 'JSON'
+require 'json'
 
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
Hi! I ran into this gem while evaluating the dependencies of a project I’m working on and noticed TravisCI was grey… So I spend some time trying to fix it, it looked accessible. I identified two issues which this pull request fixes:
- `require 'json'` should be lower case
- uninstalling `bundler` when is a default gem doesn’t work ([here’s an unsuccessful example](https://travis-ci.org/github/nathanvda/cocoon/jobs/725191266#L217))