### PR TITLE
Add event listener for @hotwired/turbo

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -132,7 +132,7 @@
   });
 
 
-  $(document).on("ready page:load turbolinks:load", function() {
+  $(document).on("ready page:load turbolinks:load turbo:load", function() {
     $('.remove_fields.existing.destroyed').each(function(i, obj) {
       var $this = $(this),
           wrapper_class = $this.data('wrapper-class') || 'nested-fields';


### PR DESCRIPTION
This adds support for [the `turbo:load` event of Turbo Drive](https://turbo.hotwire.dev/reference/events), which as I understand it is the new version of Turbolinks.