### PR TITLE
Fix jquery deprecation.

### DIFF
--- a/app/assets/javascripts/cocoon.js
+++ b/app/assets/javascripts/cocoon.js
@@ -131,16 +131,20 @@
     }
   });
 
-
-  $(document).on("ready page:load turbolinks:load turbo:load", function() {
+  var hideRemoveFields = function() {
     $('.remove_fields.existing.destroyed').each(function(i, obj) {
       var $this = $(this),
           wrapper_class = $this.data('wrapper-class') || 'nested-fields';
 
       $this.closest('.' + wrapper_class).hide();
     });
-  });
+  };
 
+  $(function() {
+    hideRemoveFields();
+    $(document).on('page:load turbolinks:load turbo:load', hideRemoveFields); // Turbolinks support
+  });
+  
 })(jQuery);
 
 


### PR DESCRIPTION
This is an updated pull request to fix the jquery ready event deprecation. As more and more deployments are moving to newer Jquery versions, it would be a good idea to fix this once and for all.

I've reviewed all the previous pull requests such as #575, #447, and #379. It looks like all of them had problems but #447 had a proper fix in the notes, only the original contributor never updated the pull request.

I've updated the pull based on the solution in #447 but with the updated events `page:load turbolinks:load turbo:load`.