### PR TITLE
Migrate CI from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+        gemfile:
+          - gemfiles/Gemfile.default
+        include:
+          - ruby-version: 2.1
+            gemfile: gemfiles/Gemfile.rails-3.2.13
+          - ruby-version: 2.1
+            gemfile: gemfiles/Gemfile.rails-4-r2
+    env:
+      BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby-version }}"
+          bundler: 1.17.3
+          bundler-cache: true
+      - name: Run spec
+        run: bundle exec rake


### PR DESCRIPTION
Since June 15th, 2021, the building on [travis-ci.org](http://www.travis-ci.org/) is ceased.
This PR migrates CI from Travis CI to GitHub Actions.

- Tests were being run on multiple patch versions(like 2.4.1, 2.4.5 and 2.4.6), now only the latest patch version will be tested.
- [ruby/setup-ruby](https://github.com/ruby/setup-ruby) does not support Rubinius(rbx-2), so rbx-2 is not included in the CI matrix.
- Use Bundler v1.x for Rails 4 and earlier.


- Comparison of CI jobs:
  - Travis CI
    ![travis](https://user-images.githubusercontent.com/32959831/151664663-4d3f1d3a-5566-4754-9038-46cf7717a9a6.png)
  - GitHub Actions
    ![gha](https://user-images.githubusercontent.com/32959831/151664661-b275537e-e6da-4630-a036-1b8f722a1a75.png)
    https://github.com/mishina2228/cocoon/actions/runs/1765938505