### PR TITLE
Use https for GitHub link

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ begin
     gem.summary = %Q{gem that enables easier nested forms with standard forms, formtastic and simple-form}
     gem.description = %Q{Unobtrusive nested forms handling, using jQuery. Use this and discover cocoon-heaven.}
     gem.email = "nathan@dixis.com"
-    gem.homepage = "http://github.com/nathanvda/cocoon"
+    gem.homepage = "https://github.com/nathanvda/cocoon"
     gem.authors = ["Nathan Van der Auwera"]
     gem.licenses = ["MIT"]
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
@@ -86,4 +86,3 @@ namespace :npm do
     system("npm publish ./pkg/nathanvda-cocoon-#{spec.version}.tgz --access public")
   end
 end
-

--- a/cocoon.gemspec
+++ b/cocoon.gemspec
@@ -84,7 +84,7 @@ Gem::Specification.new do |s|
     "spec/support/rails_version_helper.rb",
     "spec/support/shared_examples.rb"
   ]
-  s.homepage = "http://github.com/nathanvda/cocoon".freeze
+  s.homepage = "https://github.com/nathanvda/cocoon".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "3.0.8".freeze
   s.summary = "gem that enables easier nested forms with standard forms, formtastic and simple-form".freeze
@@ -146,4 +146,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rubinius-developer_tools>.freeze, [">= 0"])
   end
 end
-


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/cocoon or some tools or APIs that use the gem's metadata.